### PR TITLE
chore(sdk-python): sync egg-info sources manifest

### DIFF
--- a/sdk-python/src/agent_did_sdk.egg-info/SOURCES.txt
+++ b/sdk-python/src/agent_did_sdk.egg-info/SOURCES.txt
@@ -9,11 +9,14 @@ src/agent_did_sdk.egg-info/dependency_links.txt
 src/agent_did_sdk.egg-info/requires.txt
 src/agent_did_sdk.egg-info/top_level.txt
 src/agent_did_sdk/core/__init__.py
+src/agent_did_sdk/core/http_security.py
 src/agent_did_sdk/core/identity.py
+src/agent_did_sdk/core/signer.py
 src/agent_did_sdk/core/time_utils.py
 src/agent_did_sdk/core/types.py
 src/agent_did_sdk/crypto/__init__.py
 src/agent_did_sdk/crypto/hash.py
+src/agent_did_sdk/crypto/multibase.py
 src/agent_did_sdk/registry/__init__.py
 src/agent_did_sdk/registry/evm_registry.py
 src/agent_did_sdk/registry/evm_types.py
@@ -28,6 +31,7 @@ src/agent_did_sdk/resolver/types.py
 src/agent_did_sdk/resolver/universal.py
 tests/test_crypto.py
 tests/test_evm_registry.py
+tests/test_http_security.py
 tests/test_http_source.py
 tests/test_identity.py
 tests/test_in_memory_registry.py


### PR DESCRIPTION
Sincroniza [SOURCES.txt](vscode-file://vscode-app/c:/Users/emuno/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) con los archivos reales del SDK Python.

No agrega funcionalidad nueva. Solo corrige metadata de empaquetado para reflejar módulos y tests ya existentes.