### PR TITLE
Develop promotion

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -1,0 +1,113 @@
+name: Publish Python SDK to PyPI
+
+on:
+  push:
+    tags:
+      - "sdk-python-v*"
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Target package repository"
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+concurrency:
+  group: publish-python-sdk-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Python SDK distribution
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches sdk-python version
+        if: startsWith(github.ref, 'refs/tags/sdk-python-v')
+        working-directory: sdk-python
+        run: |
+          PACKAGE_VERSION=$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          print(data["project"]["version"])
+          PY
+          )
+          TAG_VERSION="${GITHUB_REF_NAME#sdk-python-v}"
+
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag version $TAG_VERSION does not match sdk-python/pyproject.toml version $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Build Python SDK distribution
+        working-directory: sdk-python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: python-sdk-dist
+          path: sdk-python/dist/*
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish Python SDK to TestPyPI
+    if: github.event_name == 'workflow_dispatch' && inputs.repository == 'testpypi'
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-sdk-dist
+          path: dist
+
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish Python SDK to PyPI
+    if: startsWith(github.ref, 'refs/tags/sdk-python-v') || (github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi' && github.ref == 'refs/heads/main')
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-sdk-dist
+          path: dist
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/docs/SDK-Release-Checklist.md
+++ b/docs/SDK-Release-Checklist.md
@@ -71,7 +71,12 @@ python -m ruff check src/ tests/ scripts/
 python -m mypy --strict src/
 python -m pytest tests/ -q
 python scripts/conformance_rfc001.py
+python -m build
+python -m twine check dist/*
 ```
+
+GitHub release automation for the package is defined in `.github/workflows/publish-python-sdk.yml`.
+Use `workflow_dispatch` with `repository=testpypi` for rehearsal, and publish to PyPI from tag `sdk-python-vX.Y.Z` or manual dispatch from `main` with `repository=pypi`.
 
 Checklist:
 
@@ -79,8 +84,11 @@ Checklist:
 - [ ] `python -m mypy --strict src/`
 - [ ] `python -m pytest tests/ -q`
 - [ ] `python scripts/conformance_rfc001.py`
+- [ ] `python -m build`
+- [ ] `python -m twine check dist/*`
 - [ ] If Python public API changed, `sdk-python/README.md` is updated.
 - [ ] `sdk-python/pyproject.toml` metadata and version are correct for the release.
+- [ ] PyPI Trusted Publishing is configured for `.github/workflows/publish-python-sdk.yml` in PyPI and, if used, TestPyPI.
 
 ---
 

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -174,6 +174,34 @@ python scripts/revocation_policy_smoke.py
 python scripts/e2e_smoke.py
 ```
 
+## Maintainer Release to PyPI
+
+The repository includes `.github/workflows/publish-python-sdk.yml` for PyPI Trusted Publishing.
+
+Before the first release, create the `agent-did-sdk` project on PyPI and, optionally, TestPyPI, then register GitHub Trusted Publishers for:
+
+- repository: `edisonduran/agent-did`
+- workflow file: `.github/workflows/publish-python-sdk.yml`
+- workflow trigger: tag `sdk-python-vX.Y.Z` for PyPI, `workflow_dispatch` for TestPyPI or manual PyPI release
+
+If you want GitHub environment approvals, add matching environments later and bind them in both GitHub and PyPI Trusted Publishing settings.
+
+Release preparation:
+
+```bash
+cd sdk-python
+python -m pip install -e ".[dev]"
+python -m build
+python -m twine check dist/*
+```
+
+Release flow:
+
+- bump `version` in `pyproject.toml`
+- run the workflow manually with `repository=testpypi` to validate the package on TestPyPI
+- publish to PyPI by pushing a tag named `sdk-python-vX.Y.Z`
+- alternatively, run the workflow manually from `main` with `repository=pypi`
+
 ## License
 
 [Apache-2.0](../LICENSE) — see root LICENSE.

--- a/sdk-python/src/agent_did_sdk.egg-info/PKG-INFO
+++ b/sdk-python/src/agent_did_sdk.egg-info/PKG-INFO
@@ -207,6 +207,34 @@ python scripts/revocation_policy_smoke.py
 python scripts/e2e_smoke.py
 ```
 
+## Maintainer Release to PyPI
+
+The repository includes `.github/workflows/publish-python-sdk.yml` for PyPI Trusted Publishing.
+
+Before the first release, create the `agent-did-sdk` project on PyPI and, optionally, TestPyPI, then register GitHub Trusted Publishers for:
+
+- repository: `edisonduran/agent-did`
+- workflow file: `.github/workflows/publish-python-sdk.yml`
+- workflow trigger: tag `sdk-python-vX.Y.Z` for PyPI, `workflow_dispatch` for TestPyPI or manual PyPI release
+
+If you want GitHub environment approvals, add matching environments later and bind them in both GitHub and PyPI Trusted Publishing settings.
+
+Release preparation:
+
+```bash
+cd sdk-python
+python -m pip install -e ".[dev]"
+python -m build
+python -m twine check dist/*
+```
+
+Release flow:
+
+- bump `version` in `pyproject.toml`
+- run the workflow manually with `repository=testpypi` to validate the package on TestPyPI
+- publish to PyPI by pushing a tag named `sdk-python-vX.Y.Z`
+- alternatively, run the workflow manually from `main` with `repository=pypi`
+
 ## License
 
 [Apache-2.0](../LICENSE) — see root LICENSE.


### PR DESCRIPTION
## Summary

Promote the Python SDK publishing workflow from `develop` to `main` so the repository can publish `agent-did-sdk` to TestPyPI and PyPI using GitHub Actions Trusted Publishing.

## Changes

- add the GitHub Actions workflow for Python SDK publishing
- support manual publishing to TestPyPI with `workflow_dispatch`
- support publishing to PyPI from tags named `sdk-python-vX.Y.Z`
- verify that the release tag matches the version declared in `sdk-python/pyproject.toml`
- document the maintainer release flow for PyPI/TestPyPI
- extend the Python SDK release checklist with package build and `twine check`

## Files included

- `.github/workflows/publish-python-sdk.yml`
- `docs/SDK-Release-Checklist.md`
- `sdk-python/README.md`
- `sdk-python/src/agent_did_sdk.egg-info/PKG-INFO`

## Validation

- ran `python -m build`
- ran `python -m twine check dist/*`

## Notes

- this promotion makes the workflow available on the default branch (`main`)
- once merged, `workflow_dispatch` can be used to validate the first release on TestPyPI
- PyPI and TestPyPI Trusted Publishers are already configured