### PR TITLE
feat(maf): add add_verified_handoff helper for workflow handoff identity verification (#26)

### DIFF
--- a/integrations/microsoft-agent-framework/README.md
+++ b/integrations/microsoft-agent-framework/README.md
@@ -67,6 +67,64 @@ El bundle devuelto incluye:
 - `create_function_executor(...)` para reducers y handlers tipados compatibles con `fan-in`.
 - `create_workflow_builder(...)` y `build_workflow_chain(...)` para recipes y runtime coverage de workflows.
 - `build_fan_out_fan_in_workflow(...)`, `build_multi_selection_workflow(...)` y `build_switch_case_workflow(...)` para patrones avanzados del runtime.
+- `add_verified_handoff(...)` sobre el `WorkflowBuilder` para insertar verificacion de identidad en los bordes de handoff con TTL por `action_class` (ver seccion de abajo).
+
+## Verified handoffs (`add_verified_handoff`)
+
+Inserta un verificador de Agent-DID en el borde entre dos executors de un workflow. Hard gate fail-closed con TTL por `action_class`, soporte de la race condition de rotacion de llave durante el handoff y disposicion de bloqueo via excepcion tipada (default) o callback opt-in.
+
+```python
+from agent_did_microsoft_agent_framework import (
+    SignedHandoffMessage,
+    VerificationBlockedError,
+    create_agent_did_microsoft_agent_framework_integration,
+)
+
+integration = create_agent_did_microsoft_agent_framework_integration(...)
+
+builder = integration.create_workflow_builder(start_executor=intake)
+builder.add_edge(intake, enrichment)
+builder.add_verified_handoff(
+    from_executor=enrichment,
+    to_executor=execution,
+    action_class="reversible",        # irreversible | compensable | reversible
+    allowed_dids=["did:wba:trusted"],
+    require_signature=True,
+    on_verification_blocked=None,     # default = raise VerificationBlockedError
+    output_type=str,
+)
+```
+
+Defaults TTL (overridables por workflow, no por encima de los topes para `irreversible` y cross-domain):
+
+| `action_class` | TTL default |
+|---|---|
+| `irreversible` | 30 s (no widenable) |
+| `compensable`  | 120 s |
+| `reversible`   | 300 s |
+
+Reglas adicionales:
+- Cross-domain hops fuerzan re-verify (TTL = 0).
+- Dentro del TTL: si la firma fue emitida bajo la llave previa y el agente roto su llave, se acepta via `verify_historical_signature` del SDK central.
+- Fuera del TTL: solo se acepta firma contra el current key set; si la llave previa fue revocada -> `VerificationBlockedError(failing_gates=["key_lifecycle"])`.
+
+Disposicion de bloqueo:
+- Default: levanta `VerificationBlockedError(result, failing_gates, enforcement_note, checked_did, action_class)`.
+- Opt-in: si registras `on_verification_blocked=callback`, recibe el mismo error. Devolver `None` detiene el workflow grasiosamente; devolver cualquier otro valor lo emite via `ctx.send_message(...)` como salida del verificador.
+
+Observabilidad:
+- `agent_did.workflow.handoff_verified` en exitos (incluye `from_did`, `action_class`, `ttl_seconds`, `decision_reason`).
+- `agent_did.workflow.handoff_blocked` en bloqueos (incluye `failing_gates`, `decision_reason`).
+
+Ejemplo end-to-end: [`examples/agent_did_microsoft_agent_framework_verified_handoff_example.py`](examples/agent_did_microsoft_agent_framework_verified_handoff_example.py).
+
+### Credito de diseno
+
+El diseno de esta API surgio de una conversacion publica con [@haroldmalikfrimpong-ops](https://github.com/haroldmalikfrimpong-ops) en `microsoft/agent-framework#4842`. Hilos de referencia:
+- Discusion original (handoff boundary vs middleware): [microsoft/agent-framework#4842](https://github.com/microsoft/agent-framework/issues/4842).
+- Issue concreto con la API completa lockeada: [edisonduran/agent-did#26](https://github.com/edisonduran/agent-did/issues/26).
+- Race condition de key-rotation durante handoff: [microsoft/agent-framework#4842 (comentario)](https://github.com/microsoft/agent-framework/issues/4842#issuecomment-4327716940).
+
 
 ## Tools expuestas por defecto
 

--- a/integrations/microsoft-agent-framework/examples/agent_did_microsoft_agent_framework_verified_handoff_example.py
+++ b/integrations/microsoft-agent-framework/examples/agent_did_microsoft_agent_framework_verified_handoff_example.py
@@ -24,7 +24,6 @@ from agent_did_sdk import (
     CreateAgentParams,
     InMemoryAgentRegistry,
 )
-
 from agent_framework import WorkflowContext
 
 from agent_did_microsoft_agent_framework import (

--- a/integrations/microsoft-agent-framework/examples/agent_did_microsoft_agent_framework_verified_handoff_example.py
+++ b/integrations/microsoft-agent-framework/examples/agent_did_microsoft_agent_framework_verified_handoff_example.py
@@ -1,0 +1,123 @@
+"""End-to-end example for ``add_verified_handoff`` (issue #26).
+
+Builds a 3-executor workflow with one verified handoff between the second and
+third stages. Demonstrates:
+
+- ``SignedHandoffMessage`` wiring (upstream wraps the message with signature
+  metadata produced via the SDK).
+- Default ``action_class="reversible"`` TTL semantics.
+- Observability events emitted by the verifier (``handoff_verified``).
+
+Reference threads:
+- microsoft/agent-framework#4842
+- edisonduran/agent-did#26
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from agent_did_sdk import (
+    AgentIdentity,
+    AgentIdentityConfig,
+    CreateAgentParams,
+    InMemoryAgentRegistry,
+)
+
+from agent_framework import WorkflowContext
+
+from agent_did_microsoft_agent_framework import (
+    SignedHandoffMessage,
+    create_agent_did_microsoft_agent_framework_integration,
+)
+
+
+async def main() -> None:
+    AgentIdentity.set_registry(InMemoryAgentRegistry())
+    identity = AgentIdentity(
+        AgentIdentityConfig(signer_address="0x4242424242424242424242424242424242424242")
+    )
+    runtime_identity = await identity.create(
+        CreateAgentParams(
+            name="VerifiedHandoffDemo",
+            core_model="gpt-4.1-mini",
+            system_prompt="Demo agent for verified handoff.",
+        )
+    )
+
+    events: list[dict] = []
+
+    def on_event(event):
+        events.append({"event_type": event.event_type, **event.attributes})
+
+    integration = create_agent_did_microsoft_agent_framework_integration(
+        agent_identity=identity,
+        runtime_identity=runtime_identity,
+        observability_handler=on_event,
+    )
+
+    # Stage 1 — intake. Forwards the raw payload via the workflow context.
+    async def intake(payload: str, ctx: WorkflowContext[str]) -> None:
+        await ctx.send_message(f"intake:{payload}")
+
+    # Stage 2 — enrichment. Wraps its output as a SignedHandoffMessage so the
+    # verifier can enforce identity at the next edge.
+    async def enrichment(payload: str, ctx: WorkflowContext[SignedHandoffMessage]) -> None:
+        signed_payload = f"enrichment:{payload}"
+        signature = await identity.sign_message(signed_payload, runtime_identity.agent_private_key)
+        await ctx.send_message(
+            SignedHandoffMessage(
+                payload=signed_payload,
+                did=runtime_identity.document.id,
+                signature=signature,
+                signed_at=time.time(),
+                key_id=f"{runtime_identity.document.id}#key-1",
+            )
+        )
+
+    # Stage 3 — execution. Receives the inner payload after verification and
+    # yields it as the workflow's final output.
+    async def execution(payload: str, ctx: WorkflowContext[str, str]) -> None:
+        await ctx.yield_output(f"execution:{payload}")
+
+    intake_executor = integration.create_function_executor(
+        intake, executor_id="intake", input_type=str, output_type=str
+    )
+    enrichment_executor = integration.create_function_executor(
+        enrichment, executor_id="enrichment", input_type=str, output_type=SignedHandoffMessage
+    )
+    execution_executor = integration.create_function_executor(
+        execution,
+        executor_id="execution",
+        input_type=str,
+        output_type=str,
+        workflow_output_type=str,
+    )
+
+    builder = integration.create_workflow_builder(
+        intake_executor,
+        name="verified_handoff_demo",
+        output_executors=[execution_executor],
+    )
+    builder.add_edge(intake_executor, enrichment_executor)
+    builder.add_verified_handoff(
+        from_executor=enrichment_executor,
+        to_executor=execution_executor,
+        action_class="reversible",
+        allowed_dids=[runtime_identity.document.id],
+        output_type=str,
+    )
+    workflow = builder.build()
+
+    await workflow.run("approve:order-42")
+
+    verified = [e for e in events if e["event_type"] == "agent_did.workflow.handoff_verified"]
+    print(f"Workflow completed. Verified handoffs emitted: {len(verified)}")
+    if verified:
+        print(f"  from_did={verified[0]['from_did']}")
+        print(f"  action_class={verified[0]['action_class']} ttl_seconds={verified[0]['ttl_seconds']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/__init__.py
+++ b/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/__init__.py
@@ -2,8 +2,18 @@
 
 from .config import AgentDidExposureConfig, AgentDidMicrosoftAgentFrameworkConfig
 from .context import build_agent_did_instructions, compose_instructions
+from .handoff import (
+    HANDOFF_TTL_DEFAULTS,
+    ActionClass,
+    SignedHandoffMessage,
+    VerificationBlockedCallback,
+    VerificationBlockedError,
+    build_handoff_verifier_executor,
+    build_handoff_verifier_function,
+)
 from .integration import (
     AgentDidMicrosoftAgentFrameworkIntegration,
+    AgentDidWorkflowBuilder,
     create_agent_did_microsoft_agent_framework_integration,
 )
 from .observability import (
@@ -24,14 +34,22 @@ createAgentDidMicrosoftAgentFrameworkIntegration = create_agent_did_microsoft_ag
 
 __all__ = [
     "PACKAGE_STATUS",
+    "ActionClass",
     "AgentDidEventHandler",
     "AgentDidExposureConfig",
     "AgentDidIdentitySnapshot",
     "AgentDidMicrosoftAgentFrameworkConfig",
     "AgentDidMicrosoftAgentFrameworkIntegration",
     "AgentDidMicrosoftAgentFrameworkObservabilityEvent",
+    "AgentDidWorkflowBuilder",
+    "HANDOFF_TTL_DEFAULTS",
+    "SignedHandoffMessage",
+    "VerificationBlockedCallback",
+    "VerificationBlockedError",
     "build_agent_did_identity_snapshot",
     "build_agent_did_instructions",
+    "build_handoff_verifier_executor",
+    "build_handoff_verifier_function",
     "compose_event_handlers",
     "compose_instructions",
     "createAgentDidMicrosoftAgentFrameworkIntegration",

--- a/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/handoff.py
+++ b/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/handoff.py
@@ -1,0 +1,391 @@
+"""Verified-handoff helper for Microsoft Agent Framework workflows.
+
+Implements the `add_verified_handoff(...)` design locked with @haroldmalikfrimpong-ops
+in https://github.com/edisonduran/agent-did/issues/26 and the originating thread
+`microsoft/agent-framework#4842`.
+
+Design contract (locked):
+- Hard gate, fail-closed at the handoff boundary.
+- `action_class` first-class parameter drives TTL semantics.
+- Default behavior on a blocked handoff is to raise ``VerificationBlockedError``;
+  callers may opt in via ``on_verification_blocked`` callback to either halt the
+  workflow gracefully (return ``None``) or route to a custom executor result
+  (return any value, which becomes the verifier executor's output).
+- Cross-domain hops always force a fresh verification (TTL collapses to 0).
+- ``action_class="irreversible"`` always forces a fresh verification regardless of
+  any larger TTL the caller may try to override.
+- Key-rotation race: signatures issued under a previous key remain accepted while
+  inside the action-class TTL window via the SDK's historical signature path.
+  Once the TTL elapses, the next handoff MUST re-verify against the agent's
+  current key set.
+
+This module deliberately delegates ALL key-lifecycle logic to the central SDK
+primitives (``AgentIdentity.verify_signature`` and
+``AgentIdentity.verify_historical_signature``). It must not re-implement the
+key rotation state machine — when the spec converges with `aeoess/agent-passport-system`
+the SDK is the single source of truth and this helper inherits any change for free.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from agent_did_sdk import AgentIdentity
+from agent_framework import FunctionExecutor, WorkflowContext
+
+from .observability import AgentDidObserver
+
+ActionClass = Literal["irreversible", "compensable", "reversible"]
+
+HANDOFF_TTL_DEFAULTS: dict[ActionClass, int] = {
+    "irreversible": 30,
+    "compensable": 120,
+    "reversible": 300,
+}
+
+VerificationBlockedCallback = Callable[["VerificationBlockedError"], Any]
+
+
+@dataclass(slots=True)
+class SignedHandoffMessage:
+    """Wrapper carrying the signature metadata required at a handoff boundary.
+
+    Upstream executors MUST emit a ``SignedHandoffMessage`` when handing off across
+    a verified edge. The verifier extracts ``payload`` after a successful check and
+    forwards it to the downstream executor unchanged.
+    """
+
+    payload: Any
+    did: str
+    signature: str
+    signed_at: float
+    key_id: str | None = None
+    trust_domain: str | None = None
+
+
+class VerificationBlockedError(Exception):
+    """Raised by ``add_verified_handoff`` when a handoff fails verification.
+
+    Attributes match the shape locked in
+    https://github.com/microsoft/agent-framework/issues/4842#issuecomment-4327716940.
+    """
+
+    def __init__(
+        self,
+        *,
+        result: dict[str, Any],
+        failing_gates: Sequence[str],
+        enforcement_note: str,
+        checked_did: str | None,
+        action_class: ActionClass,
+    ) -> None:
+        super().__init__(enforcement_note)
+        self.result = result
+        self.failing_gates = list(failing_gates)
+        self.enforcement_note = enforcement_note
+        self.checked_did = checked_did
+        self.action_class = action_class
+
+
+@dataclass(slots=True)
+class _VerifierContext:
+    from_executor_id: str
+    to_executor_id: str
+    action_class: ActionClass
+    ttl_seconds: int
+    allowed_dids: tuple[str, ...] | None
+    require_signature: bool
+    cross_domain: bool
+    on_verification_blocked: VerificationBlockedCallback | None
+    observer: AgentDidObserver
+    verify_signature: Callable[..., Any] = field(default=AgentIdentity.verify_signature)
+    verify_historical_signature: Callable[..., Any] = field(
+        default=AgentIdentity.verify_historical_signature
+    )
+    now: Callable[[], float] = field(default=time.time)
+
+
+def _resolve_executor_id(executor: Any) -> str:
+    return getattr(executor, "id", None) or getattr(executor, "name", None) or type(executor).__name__
+
+
+def _resolve_effective_ttl(
+    action_class: ActionClass,
+    ttl_seconds: int | None,
+    cross_domain: bool,
+) -> int:
+    if cross_domain:
+        return 0
+    if action_class == "irreversible":
+        # Irreversible always uses the (small) action-class default; callers cannot widen it.
+        return HANDOFF_TTL_DEFAULTS["irreversible"]
+    if ttl_seconds is not None:
+        return max(0, int(ttl_seconds))
+    return HANDOFF_TTL_DEFAULTS[action_class]
+
+
+def _build_block_error(
+    *,
+    failing_gates: Sequence[str],
+    checked_did: str | None,
+    action_class: ActionClass,
+    enforcement_note: str,
+) -> VerificationBlockedError:
+    return VerificationBlockedError(
+        result={
+            "valid": False,
+            "did": checked_did,
+            "failing_gates": list(failing_gates),
+            "action_class": action_class,
+        },
+        failing_gates=failing_gates,
+        enforcement_note=enforcement_note,
+        checked_did=checked_did,
+        action_class=action_class,
+    )
+
+
+def _emit_blocked(observer: AgentDidObserver, ctx: _VerifierContext, error: VerificationBlockedError) -> None:
+    observer.emit(
+        "agent_did.workflow.handoff_blocked",
+        attributes={
+            "from_executor": ctx.from_executor_id,
+            "to_executor": ctx.to_executor_id,
+            "from_did": error.checked_did,
+            "action_class": ctx.action_class,
+            "ttl_seconds": ctx.ttl_seconds,
+            "failing_gates": error.failing_gates,
+            "decision_reason": error.enforcement_note,
+        },
+        level="error",
+    )
+
+
+def _emit_verified(
+    observer: AgentDidObserver,
+    ctx: _VerifierContext,
+    *,
+    from_did: str,
+    used_historical: bool,
+    staleness_seconds: float,
+) -> None:
+    observer.emit(
+        "agent_did.workflow.handoff_verified",
+        attributes={
+            "from_executor": ctx.from_executor_id,
+            "to_executor": ctx.to_executor_id,
+            "from_did": from_did,
+            "to_did": None,
+            "action_class": ctx.action_class,
+            "ttl_seconds": ctx.ttl_seconds,
+            "decision_reason": "ok",
+            "used_historical_signature": used_historical,
+            "staleness_seconds": staleness_seconds,
+        },
+    )
+
+
+def _handle_block(ctx: _VerifierContext, error: VerificationBlockedError) -> Any:
+    """Legacy synchronous block handler.
+
+    Retained for callers that exercise the verifier directly without a workflow
+    context (returns the callback value or raises). The async path used inside
+    ``build_handoff_verifier_function`` calls ``_emit_block_outcome`` instead.
+    """
+
+    _emit_blocked(ctx.observer, ctx, error)
+    if ctx.on_verification_blocked is None:
+        raise error
+    return ctx.on_verification_blocked(error)
+
+
+def build_handoff_verifier_function(ctx: _VerifierContext) -> Callable[..., Any]:
+    """Build the async function that backs the verifier ``FunctionExecutor``.
+
+    The returned coroutine accepts ``(message, wf_ctx)`` where ``wf_ctx`` is the
+    Microsoft Agent Framework ``WorkflowContext``. On success the inner payload
+    is forwarded via ``await wf_ctx.send_message(payload)``. On failure the
+    behaviour follows the locked design contract:
+
+    - If no ``on_verification_blocked`` callback is registered, raise
+      ``VerificationBlockedError``.
+    - If a callback is registered and returns ``None``, halt gracefully (no
+      message is sent downstream).
+    - If a callback is registered and returns any other value, forward that value
+      via ``await wf_ctx.send_message(value)``.
+    """
+
+    async def _verifier(message: Any, wf_ctx: WorkflowContext[Any]) -> None:
+        if not isinstance(message, SignedHandoffMessage):
+            await _emit_unsigned_outcome(ctx, wf_ctx, message)
+            return
+
+        if ctx.allowed_dids is not None and message.did not in ctx.allowed_dids:
+            error = _build_block_error(
+                failing_gates=["did_allowlist"],
+                checked_did=message.did,
+                action_class=ctx.action_class,
+                enforcement_note=f"DID {message.did!r} not in allowed_dids",
+            )
+            await _emit_block_outcome(ctx, wf_ctx, error)
+            return
+
+        valid, used_historical, staleness, gate = await _run_signature_verification(ctx, message)
+        if not valid:
+            error = _build_block_error(
+                failing_gates=[gate],
+                checked_did=message.did,
+                action_class=ctx.action_class,
+                enforcement_note=_block_note_for_gate(gate, ctx.ttl_seconds, message.did),
+            )
+            await _emit_block_outcome(ctx, wf_ctx, error)
+            return
+
+        _emit_verified(
+            ctx.observer, ctx,
+            from_did=message.did, used_historical=used_historical, staleness_seconds=staleness,
+        )
+        await wf_ctx.send_message(message.payload)
+
+    return _verifier
+
+
+async def _emit_unsigned_outcome(ctx: _VerifierContext, wf_ctx: Any, message: Any) -> None:
+    if not ctx.require_signature:
+        await wf_ctx.send_message(message)
+        return
+    error = _build_block_error(
+        failing_gates=["signature"],
+        checked_did=None,
+        action_class=ctx.action_class,
+        enforcement_note="Handoff message is not a SignedHandoffMessage and require_signature=True",
+    )
+    await _emit_block_outcome(ctx, wf_ctx, error)
+
+
+async def _emit_block_outcome(ctx: _VerifierContext, wf_ctx: Any, error: VerificationBlockedError) -> None:
+    _emit_blocked(ctx.observer, ctx, error)
+    if ctx.on_verification_blocked is None:
+        raise error
+    callback_result = ctx.on_verification_blocked(error)
+    if callback_result is None:
+        return  # halt gracefully
+    await wf_ctx.send_message(callback_result)
+
+
+def _block_note_for_gate(gate: str, ttl_seconds: int, did: str) -> str:
+    if gate == "key_lifecycle":
+        return (
+            f"Signature past action-class TTL ({ttl_seconds}s) and the previous key "
+            "no longer verifies against the current key set"
+        )
+    return f"Signature did not verify against the current or historical key set for {did}"
+
+
+async def _run_signature_verification(
+    ctx: _VerifierContext, message: SignedHandoffMessage
+) -> tuple[bool, bool, float, str]:
+    """Return ``(valid, used_historical, staleness_seconds, failing_gate)``.
+
+    ``failing_gate`` is meaningful only when ``valid`` is ``False``.
+    """
+
+    payload_str = message.payload if isinstance(message.payload, str) else str(message.payload)
+    staleness = max(0.0, ctx.now() - message.signed_at)
+
+    if staleness > ctx.ttl_seconds:
+        valid = await ctx.verify_signature(
+            message.did, payload_str, message.signature, message.key_id
+        )
+        return bool(valid), False, staleness, "key_lifecycle"
+
+    valid = await ctx.verify_signature(
+        message.did, payload_str, message.signature, message.key_id
+    )
+    used_historical = False
+    if not valid and message.key_id:
+        valid = await ctx.verify_historical_signature(
+            message.did, payload_str, message.signature, message.key_id
+        )
+        used_historical = bool(valid)
+    return bool(valid), used_historical, staleness, "signature"
+
+
+def build_handoff_verifier_executor(
+    *,
+    from_executor: Any,
+    to_executor: Any,
+    action_class: ActionClass,
+    ttl_seconds: int | None,
+    allowed_dids: Sequence[str] | None,
+    require_signature: bool,
+    cross_domain: bool | None,
+    on_verification_blocked: VerificationBlockedCallback | None,
+    observer: AgentDidObserver,
+    executor_id: str | None = None,
+    output_type: Any = object,
+) -> FunctionExecutor:
+    """Build the ``FunctionExecutor`` that enforces verification at a handoff edge."""
+
+    from_id = _resolve_executor_id(from_executor)
+    to_id = _resolve_executor_id(to_executor)
+    from_domain = getattr(from_executor, "trust_domain", None)
+    to_domain = getattr(to_executor, "trust_domain", None)
+    if cross_domain is None:
+        cross_domain = bool(from_domain and to_domain and from_domain != to_domain)
+
+    effective_ttl = _resolve_effective_ttl(action_class, ttl_seconds, cross_domain)
+
+    ctx = _VerifierContext(
+        from_executor_id=from_id,
+        to_executor_id=to_id,
+        action_class=action_class,
+        ttl_seconds=effective_ttl,
+        allowed_dids=tuple(allowed_dids) if allowed_dids is not None else None,
+        require_signature=require_signature,
+        cross_domain=cross_domain,
+        on_verification_blocked=on_verification_blocked,
+        observer=observer,
+    )
+
+    verifier_func = build_handoff_verifier_function(ctx)
+    resolved_executor_id = executor_id or f"agent_did_verified_handoff__{from_id}__{to_id}"
+    # Declare explicit IO types so the workflow validator doesn't skip edge checks
+    # for this implicit executor we inserted on the user's behalf. Inputs are
+    # SignedHandoffMessage when require_signature=True; outputs are deliberately
+    # ``object`` to keep the inner payload type-agnostic (the downstream executor
+    # supplies the concrete annotation).
+    executor = FunctionExecutor(
+        verifier_func,
+        id=resolved_executor_id,
+        input=SignedHandoffMessage if require_signature else object,
+        output=output_type,
+    )
+    observer.emit(
+        "agent_did.workflow.verifier_created",
+        attributes={
+            "executor_id": resolved_executor_id,
+            "from_executor": from_id,
+            "to_executor": to_id,
+            "action_class": action_class,
+            "ttl_seconds": effective_ttl,
+            "cross_domain": cross_domain,
+            "allowed_did_count": len(ctx.allowed_dids) if ctx.allowed_dids else 0,
+            "require_signature": require_signature,
+        },
+    )
+    return executor
+
+
+__all__ = [
+    "ActionClass",
+    "HANDOFF_TTL_DEFAULTS",
+    "SignedHandoffMessage",
+    "VerificationBlockedCallback",
+    "VerificationBlockedError",
+    "build_handoff_verifier_executor",
+    "build_handoff_verifier_function",
+]

--- a/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/integration.py
+++ b/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/integration.py
@@ -12,9 +12,70 @@ from agent_framework import Agent, AgentExecutor, Case, Default, FunctionExecuto
 
 from .config import AgentDidExposureConfig, AgentDidMicrosoftAgentFrameworkConfig
 from .context import compose_instructions
+from .handoff import (
+    ActionClass,
+    VerificationBlockedCallback,
+    build_handoff_verifier_executor,
+)
 from .observability import AgentDidEventHandler, AgentDidObserver
 from .snapshot import AgentDidIdentitySnapshot, RuntimeIdentity, build_agent_did_identity_snapshot
 from .tools import create_agent_framework_tools
+
+
+class AgentDidWorkflowBuilder(WorkflowBuilder):
+    """`WorkflowBuilder` subclass exposing Agent-DID-aware handoff helpers.
+
+    The only behavioural addition is :py:meth:`add_verified_handoff`, which inserts
+    a verification ``FunctionExecutor`` between two existing executors. All other
+    methods inherit from the upstream ``WorkflowBuilder`` unchanged.
+    """
+
+    _agent_did_observer: AgentDidObserver | None = None
+
+    def add_verified_handoff(
+        self,
+        from_executor: Any,
+        to_executor: Any,
+        *,
+        action_class: ActionClass = "reversible",
+        allowed_dids: Sequence[str] | None = None,
+        require_signature: bool = True,
+        on_verification_blocked: VerificationBlockedCallback | None = None,
+        ttl_seconds: int | None = None,
+        cross_domain: bool | None = None,
+        executor_id: str | None = None,
+        output_type: Any = object,
+    ) -> "AgentDidWorkflowBuilder":
+        """Insert an Agent-DID verifier between ``from_executor`` and ``to_executor``.
+
+        See ``handoff.py`` for the full design contract. This method only wires
+        the verifier executor into the workflow graph; verification semantics
+        (TTL, key rotation, signature checks) live in the helper module.
+        """
+
+        if self._agent_did_observer is None:
+            raise RuntimeError(
+                "AgentDidWorkflowBuilder is missing an observer. "
+                "Use AgentDidMicrosoftAgentFrameworkIntegration.create_workflow_builder(...) "
+                "to obtain a properly wired builder."
+            )
+
+        verifier = build_handoff_verifier_executor(
+            from_executor=from_executor,
+            to_executor=to_executor,
+            action_class=action_class,
+            ttl_seconds=ttl_seconds,
+            allowed_dids=allowed_dids,
+            require_signature=require_signature,
+            cross_domain=cross_domain,
+            on_verification_blocked=on_verification_blocked,
+            observer=self._agent_did_observer,
+            executor_id=executor_id,
+            output_type=output_type,
+        )
+        self.add_edge(from_executor, verifier)
+        self.add_edge(verifier, to_executor)
+        return self
 
 
 @dataclass(slots=True)
@@ -145,7 +206,7 @@ class AgentDidMicrosoftAgentFrameworkIntegration:
         max_iterations: int = 100,
         checkpoint_storage: Any | None = None,
     ) -> WorkflowBuilder:
-        builder = WorkflowBuilder(
+        builder = AgentDidWorkflowBuilder(
             max_iterations=max_iterations,
             name=name,
             description=description,
@@ -153,6 +214,7 @@ class AgentDidMicrosoftAgentFrameworkIntegration:
             checkpoint_storage=checkpoint_storage,
             output_executors=list(output_executors) if output_executors is not None else None,
         )
+        builder._agent_did_observer = self.observer
         self.observer.emit(
             "agent_did.workflow.builder_created",
             attributes={

--- a/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/integration.py
+++ b/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/integration.py
@@ -45,7 +45,7 @@ class AgentDidWorkflowBuilder(WorkflowBuilder):
         cross_domain: bool | None = None,
         executor_id: str | None = None,
         output_type: Any = object,
-    ) -> "AgentDidWorkflowBuilder":
+    ) -> AgentDidWorkflowBuilder:
         """Insert an Agent-DID verifier between ``from_executor`` and ``to_executor``.
 
         See ``handoff.py`` for the full design contract. This method only wires

--- a/integrations/microsoft-agent-framework/tests/test_verified_handoff.py
+++ b/integrations/microsoft-agent-framework/tests/test_verified_handoff.py
@@ -1,0 +1,466 @@
+"""Tests for ``add_verified_handoff`` (issue #26).
+
+Covers the acceptance criteria locked with @haroldmalikfrimpong-ops:
+
+- Default API + parameter shape.
+- Hard gate, fail-closed: missing signature, invalid signature, expired TTL,
+  disallowed DID, cross-domain hop, irreversible action with stale verification.
+- Key-rotation race: (a) inside TTL with rotation accepted via historical sig
+  path, (b) after TTL re-verified against new key, (c) after TTL where re-verify
+  fails because previous key was revoked = blocked via
+  ``VerificationBlockedError(failing_gates=["key_lifecycle"])``.
+- ``on_verification_blocked`` callback semantics: ``None`` halts gracefully,
+  returning a value forwards it as the verifier executor's output.
+- Observability events: ``agent_did.workflow.handoff_verified`` /
+  ``agent_did.workflow.handoff_blocked`` emitted with required attributes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from agent_did_sdk import (
+    AgentIdentity,
+    AgentIdentityConfig,
+    CreateAgentParams,
+    InMemoryAgentRegistry,
+)
+
+from agent_did_microsoft_agent_framework import (
+    HANDOFF_TTL_DEFAULTS,
+    AgentDidWorkflowBuilder,
+    SignedHandoffMessage,
+    VerificationBlockedError,
+    create_agent_did_microsoft_agent_framework_integration,
+)
+from agent_did_microsoft_agent_framework.handoff import (
+    _VerifierContext,
+    _resolve_effective_ttl,
+    build_handoff_verifier_function,
+)
+from agent_did_microsoft_agent_framework.observability import AgentDidObserver
+
+
+class _FakeWorkflowContext:
+    """Minimal stand-in for ``agent_framework.WorkflowContext`` used in unit tests."""
+
+    def __init__(self) -> None:
+        self.sent: list[object] = []
+
+    async def send_message(self, value: object) -> None:
+        self.sent.append(value)
+
+
+def _run_verifier(verifier, message):
+    """Drive the verifier with a fake context and return ``(sent, fake_ctx)``."""
+    fake = _FakeWorkflowContext()
+    asyncio.run(verifier(message, fake))
+    return fake.sent, fake
+
+
+@pytest.fixture
+def integration():
+    AgentIdentity.set_registry(InMemoryAgentRegistry())
+    identity = AgentIdentity(
+        AgentIdentityConfig(signer_address="0x1010101010101010101010101010101010101010")
+    )
+    runtime_identity = asyncio.run(
+        identity.create(
+            CreateAgentParams(
+                name="HandoffTestBot",
+                core_model="gpt-4.1-mini",
+                system_prompt="Verified handoff under test.",
+            )
+        )
+    )
+    return (
+        identity,
+        runtime_identity,
+        create_agent_did_microsoft_agent_framework_integration(
+            agent_identity=identity, runtime_identity=runtime_identity
+        ),
+    )
+
+
+def _make_observer() -> tuple[AgentDidObserver, list[dict]]:
+    events: list[dict] = []
+
+    def handler(event):
+        events.append({"event_type": event.event_type, **event.attributes})
+
+    return AgentDidObserver(event_handler=handler), events
+
+
+def _ctx(
+    *,
+    observer,
+    action_class="reversible",
+    ttl_seconds=300,
+    allowed_dids=None,
+    require_signature=True,
+    cross_domain=False,
+    on_verification_blocked=None,
+    verify_signature=None,
+    verify_historical_signature=None,
+    now=None,
+):
+    return _VerifierContext(
+        from_executor_id="upstream",
+        to_executor_id="downstream",
+        action_class=action_class,
+        ttl_seconds=ttl_seconds,
+        allowed_dids=tuple(allowed_dids) if allowed_dids is not None else None,
+        require_signature=require_signature,
+        cross_domain=cross_domain,
+        on_verification_blocked=on_verification_blocked,
+        observer=observer,
+        verify_signature=verify_signature or _stub_async(True),
+        verify_historical_signature=verify_historical_signature or _stub_async(False),
+        now=now or time.time,
+    )
+
+
+def _stub_async(return_value):
+    async def _stub(*_args, **_kwargs):
+        return return_value
+
+    return _stub
+
+
+# --- Defaults & parameter shape ---------------------------------------------------------
+
+
+def test_defaults_match_locked_design() -> None:
+    assert HANDOFF_TTL_DEFAULTS == {"irreversible": 30, "compensable": 120, "reversible": 300}
+
+
+def test_resolve_effective_ttl_irreversible_cannot_be_widened() -> None:
+    assert _resolve_effective_ttl("irreversible", ttl_seconds=9999, cross_domain=False) == 30
+
+
+def test_resolve_effective_ttl_cross_domain_collapses_to_zero() -> None:
+    assert _resolve_effective_ttl("reversible", ttl_seconds=600, cross_domain=True) == 0
+
+
+def test_create_workflow_builder_returns_subclass(integration) -> None:
+    _, _, integ = integration
+
+    def _identity(message: object) -> object:
+        return message
+
+    start = integ.create_function_executor(_identity, executor_id="start")
+    builder = integ.create_workflow_builder(start)
+    assert isinstance(builder, AgentDidWorkflowBuilder)
+    assert hasattr(builder, "add_verified_handoff")
+
+
+# --- Hard gate, fail-closed -------------------------------------------------------------
+
+
+def test_unsigned_message_blocked_when_signature_required() -> None:
+    observer, events = _make_observer()
+    verifier = build_handoff_verifier_function(_ctx(observer=observer))
+    with pytest.raises(VerificationBlockedError) as exc:
+        _run_verifier(verifier, "plain string")
+    assert exc.value.failing_gates == ["signature"]
+    assert any(event["event_type"] == "agent_did.workflow.handoff_blocked" for event in events)
+
+
+def test_unsigned_message_passthrough_when_signature_not_required() -> None:
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(_ctx(observer=observer, require_signature=False))
+    sent, _ = _run_verifier(verifier, "plain string")
+    assert sent == ["plain string"]
+
+
+def test_disallowed_did_blocked() -> None:
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(observer=observer, allowed_dids=["did:wba:allowed"])
+    )
+    msg = SignedHandoffMessage(
+        payload="x", did="did:wba:other", signature="00", signed_at=time.time()
+    )
+    with pytest.raises(VerificationBlockedError) as exc:
+        _run_verifier(verifier, msg)
+    assert exc.value.failing_gates == ["did_allowlist"]
+
+
+def test_invalid_signature_blocked() -> None:
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(observer=observer, verify_signature=_stub_async(False))
+    )
+    msg = SignedHandoffMessage(
+        payload="x", did="did:wba:agent", signature="00", signed_at=time.time()
+    )
+    with pytest.raises(VerificationBlockedError) as exc:
+        _run_verifier(verifier, msg)
+    assert exc.value.failing_gates == ["signature"]
+
+
+def test_expired_ttl_with_failing_reverify_blocked_as_key_lifecycle() -> None:
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(
+            observer=observer,
+            ttl_seconds=10,
+            verify_signature=_stub_async(False),
+            now=lambda: 100.0,
+        )
+    )
+    msg = SignedHandoffMessage(
+        payload="x", did="did:wba:agent", signature="00", signed_at=50.0
+    )
+    with pytest.raises(VerificationBlockedError) as exc:
+        _run_verifier(verifier, msg)
+    assert exc.value.failing_gates == ["key_lifecycle"]
+
+
+def test_irreversible_action_with_stale_signature_forces_reverify() -> None:
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(
+            observer=observer,
+            action_class="irreversible",
+            ttl_seconds=_resolve_effective_ttl("irreversible", ttl_seconds=3600, cross_domain=False),
+            verify_signature=_stub_async(False),
+            now=lambda: 1000.0,
+        )
+    )
+    msg = SignedHandoffMessage(
+        payload="x", did="did:wba:agent", signature="00", signed_at=900.0
+    )  # 100s old > 30s TTL
+    with pytest.raises(VerificationBlockedError) as exc:
+        _run_verifier(verifier, msg)
+    assert exc.value.failing_gates == ["key_lifecycle"]
+
+
+def test_cross_domain_hop_collapses_ttl_to_zero() -> None:
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(
+            observer=observer,
+            cross_domain=True,
+            ttl_seconds=0,
+            verify_signature=_stub_async(False),
+            now=lambda: 100.0,
+        )
+    )
+    msg = SignedHandoffMessage(
+        payload="x", did="did:wba:agent", signature="00", signed_at=99.5
+    )
+    with pytest.raises(VerificationBlockedError) as exc:
+        _run_verifier(verifier, msg)
+    assert exc.value.failing_gates == ["key_lifecycle"]
+
+
+# --- Success path -----------------------------------------------------------------------
+
+
+def test_valid_signature_inside_ttl_forwards_inner_payload() -> None:
+    observer, events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(observer=observer, verify_signature=_stub_async(True))
+    )
+    msg = SignedHandoffMessage(
+        payload={"approved": True}, did="did:wba:agent", signature="aa", signed_at=time.time()
+    )
+    sent, _ = _run_verifier(verifier, msg)
+    assert sent == [{"approved": True}]
+    verified = [e for e in events if e["event_type"] == "agent_did.workflow.handoff_verified"]
+    assert verified and verified[0]["from_did"] == "did:wba:agent"
+
+
+# --- Key-rotation race (AC tests a/b/c) -------------------------------------------------
+
+
+def test_key_rotation_race_inside_ttl_accepted_via_historical_path() -> None:
+    """AC (a): inside TTL with rotation = accepted via historical sig path."""
+
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(
+            observer=observer,
+            ttl_seconds=120,
+            # Current key set rejects (rotation already happened) but historical accepts.
+            verify_signature=_stub_async(False),
+            verify_historical_signature=_stub_async(True),
+            now=lambda: 100.0,
+        )
+    )
+    msg = SignedHandoffMessage(
+        payload="approve",
+        did="did:wba:agent",
+        signature="aa",
+        signed_at=50.0,
+        key_id="did:wba:agent#key-1",
+    )
+    sent, _ = _run_verifier(verifier, msg)
+    assert sent == ["approve"]
+
+
+def test_key_rotation_race_after_ttl_reverified_against_current_key() -> None:
+    """AC (b): after TTL with rotation = re-verified against new key."""
+
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(
+            observer=observer,
+            ttl_seconds=10,
+            # Current key set accepts (re-signed by upstream after rotation).
+            verify_signature=_stub_async(True),
+            verify_historical_signature=_stub_async(False),
+            now=lambda: 100.0,
+        )
+    )
+    msg = SignedHandoffMessage(
+        payload="approve",
+        did="did:wba:agent",
+        signature="aa",
+        signed_at=50.0,
+        key_id="did:wba:agent#key-2",
+    )
+    sent, _ = _run_verifier(verifier, msg)
+    assert sent == ["approve"]
+
+
+def test_key_rotation_race_after_ttl_revoked_key_blocked_with_key_lifecycle_gate() -> None:
+    """AC (c): after TTL where re-verify fails because previous key was revoked."""
+
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(
+            observer=observer,
+            ttl_seconds=10,
+            verify_signature=_stub_async(False),
+            verify_historical_signature=_stub_async(True),  # would succeed but TTL is past
+            now=lambda: 100.0,
+        )
+    )
+    msg = SignedHandoffMessage(
+        payload="approve",
+        did="did:wba:agent",
+        signature="aa",
+        signed_at=50.0,
+        key_id="did:wba:agent#key-1",
+    )
+    with pytest.raises(VerificationBlockedError) as exc:
+        _run_verifier(verifier, msg)
+    assert exc.value.failing_gates == ["key_lifecycle"]
+
+
+# --- Real SDK key-rotation race (integration check, no mocks) ---------------------------
+
+
+def test_key_rotation_race_against_real_sdk_inside_ttl(integration) -> None:
+    """End-to-end check that the verifier wires the SDK's historical path correctly."""
+
+    identity, runtime_identity, _ = integration
+    payload = "real:rotation:inside_ttl"
+    old_key_id = f"{runtime_identity.document.id}#key-1"
+    old_sig = asyncio.run(identity.sign_message(payload, runtime_identity.agent_private_key))
+
+    asyncio.run(AgentIdentity.rotate_verification_method(runtime_identity.document.id))
+
+    observer, _events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(observer=observer, ttl_seconds=300)  # default reversible TTL
+    )
+    msg = SignedHandoffMessage(
+        payload=payload,
+        did=runtime_identity.document.id,
+        signature=old_sig,
+        signed_at=time.time(),  # fresh
+        key_id=old_key_id,
+    )
+    sent, _ = _run_verifier(verifier, msg)
+    assert sent == [payload]  # accepted via historical path
+
+
+# --- Callback semantics -----------------------------------------------------------------
+
+
+def test_callback_returning_none_halts_gracefully() -> None:
+    observer, _events = _make_observer()
+    captured: list[VerificationBlockedError] = []
+
+    def on_blocked(error):
+        captured.append(error)
+        return None
+
+    verifier = build_handoff_verifier_function(
+        _ctx(observer=observer, on_verification_blocked=on_blocked)
+    )
+    sent, _ = _run_verifier(verifier, "unsigned")
+    assert sent == []  # halt: nothing forwarded
+    assert captured and captured[0].failing_gates == ["signature"]
+
+
+def test_callback_returning_value_forwards_it_as_verifier_output() -> None:
+    observer, _events = _make_observer()
+
+    def on_blocked(_error):
+        return {"routed_to": "human_review"}
+
+    verifier = build_handoff_verifier_function(
+        _ctx(observer=observer, on_verification_blocked=on_blocked)
+    )
+    sent, _ = _run_verifier(verifier, "unsigned")
+    assert sent == [{"routed_to": "human_review"}]
+
+
+# --- Observability ----------------------------------------------------------------------
+
+
+def test_handoff_verified_event_includes_required_attributes() -> None:
+    observer, events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(observer=observer, verify_signature=_stub_async(True))
+    )
+    msg = SignedHandoffMessage(
+        payload="x", did="did:wba:agent", signature="aa", signed_at=time.time()
+    )
+    _run_verifier(verifier, msg)
+    verified = next(e for e in events if e["event_type"] == "agent_did.workflow.handoff_verified")
+    for required in ("from_executor", "to_executor", "from_did", "action_class", "ttl_seconds", "decision_reason"):
+        assert required in verified
+
+
+def test_handoff_blocked_event_includes_required_attributes() -> None:
+    observer, events = _make_observer()
+    verifier = build_handoff_verifier_function(
+        _ctx(observer=observer, verify_signature=_stub_async(False))
+    )
+    msg = SignedHandoffMessage(
+        payload="x", did="did:wba:agent", signature="00", signed_at=time.time()
+    )
+    with pytest.raises(VerificationBlockedError):
+        _run_verifier(verifier, msg)
+    blocked = next(e for e in events if e["event_type"] == "agent_did.workflow.handoff_blocked")
+    for required in ("from_executor", "to_executor", "from_did", "action_class", "ttl_seconds", "failing_gates", "decision_reason"):
+        assert required in blocked
+
+
+# --- Builder integration ----------------------------------------------------------------
+
+
+def test_add_verified_handoff_wires_two_edges_into_builder(integration) -> None:
+    _, _, integ = integration
+
+    def _identity(message: object) -> object:
+        return message
+
+    start = integ.create_function_executor(_identity, executor_id="start")
+    middle = integ.create_function_executor(_identity, executor_id="middle")
+    builder = integ.create_workflow_builder(start)
+    returned = builder.add_verified_handoff(
+        from_executor=start,
+        to_executor=middle,
+        action_class="compensable",
+        allowed_dids=["did:wba:trusted"],
+    )
+    assert returned is builder  # fluent

--- a/integrations/microsoft-agent-framework/tests/test_verified_handoff.py
+++ b/integrations/microsoft-agent-framework/tests/test_verified_handoff.py
@@ -21,7 +21,6 @@ import asyncio
 import time
 
 import pytest
-
 from agent_did_sdk import (
     AgentIdentity,
     AgentIdentityConfig,
@@ -37,8 +36,8 @@ from agent_did_microsoft_agent_framework import (
     create_agent_did_microsoft_agent_framework_integration,
 )
 from agent_did_microsoft_agent_framework.handoff import (
-    _VerifierContext,
     _resolve_effective_ttl,
+    _VerifierContext,
     build_handoff_verifier_function,
 )
 from agent_did_microsoft_agent_framework.observability import AgentDidObserver
@@ -441,7 +440,16 @@ def test_handoff_blocked_event_includes_required_attributes() -> None:
     with pytest.raises(VerificationBlockedError):
         _run_verifier(verifier, msg)
     blocked = next(e for e in events if e["event_type"] == "agent_did.workflow.handoff_blocked")
-    for required in ("from_executor", "to_executor", "from_did", "action_class", "ttl_seconds", "failing_gates", "decision_reason"):
+    required_attrs = (
+        "from_executor",
+        "to_executor",
+        "from_did",
+        "action_class",
+        "ttl_seconds",
+        "failing_gates",
+        "decision_reason",
+    )
+    for required in required_attrs:
         assert required in blocked
 
 


### PR DESCRIPTION
## Summary

Implements the locked design from #26 — discussed publicly with @haroldmalikfrimpong-ops in [microsoft/agent-framework#4842](https://github.com/microsoft/agent-framework/issues/4842).

Adds `add_verified_handoff(...)` on the `WorkflowBuilder` returned by `integration.create_workflow_builder(...)`. It inserts a hard-gate, fail-closed identity verifier on the edge between two executors of a Microsoft Agent Framework workflow, with TTL-by-`action_class`, key-rotation race handling, and structured observability.

Closes #26.

## Refs

- Issue with the locked AC checklist: #26
- Public Review thread (origin of the design): https://github.com/microsoft/agent-framework/issues/4842
- Key-rotation race framing (Harold's comment): https://github.com/microsoft/agent-framework/issues/4842#issuecomment-4327846492

## What ships

**New module** — `integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/handoff.py`

- `ActionClass = Literal["irreversible", "compensable", "reversible"]`
- `HANDOFF_TTL_DEFAULTS = {"irreversible": 30, "compensable": 120, "reversible": 300}`
- `SignedHandoffMessage` (payload, did, signature, signed_at, key_id, trust_domain)
- `VerificationBlockedError(result, failing_gates, enforcement_note, checked_did, action_class)`
- `VerificationBlockedCallback` type
- `build_handoff_verifier_executor(...)` / `build_handoff_verifier_function(...)`

**Builder integration** — `integration.py`

- `AgentDidWorkflowBuilder(WorkflowBuilder)` subclass exposing `add_verified_handoff(from_executor, to_executor, *, action_class="reversible", allowed_dids=None, require_signature=True, on_verification_blocked=None, ttl_seconds=None, cross_domain=None, executor_id=None, output_type=object)`.
- `integration.create_workflow_builder(...)` now returns this subclass with the integration's observer wired in.

**Tests** — `tests/test_verified_handoff.py` (21 tests, full suite 30/30 passing)

**Example** — `examples/agent_did_microsoft_agent_framework_verified_handoff_example.py` — 3-executor workflow validated end-to-end against the real `agent-framework` runtime, output shows 1 verified handoff with real DID, `action_class=reversible`, `ttl_seconds=300`.

**README** — section + design credit linking back to the originating threads.

## AC checklist (from #26)

- [x] API shape locked: `add_verified_handoff(from, to, *, action_class, allowed_dids, require_signature, on_verification_blocked, ttl_seconds, cross_domain, ...)`
- [x] Defaults: `action_class="reversible"`, `require_signature=True`, `on_verification_blocked=None` (raise)
- [x] TTL defaults overridable per workflow, with hard caps for `irreversible` and cross-domain (TTL = 0)
- [x] Cross-domain hops always force re-verify
- [x] `irreversible` action class always re-verifies (TTL ceiling enforced)
- [x] `VerificationBlockedError` exposes `result`, `failing_gates`, `enforcement_note`, `checked_did`, `action_class`
- [x] Opt-in callback: returning `None` halts gracefully, returning a value is forwarded via `ctx.send_message(...)`
- [x] Tests for every failure mode: missing signature, invalid signature, expired TTL, disallowed DID, cross-domain hop, `irreversible` with stale verification
- [x] Tests for the key-rotation race (a/b/c) — including one integration test that drives the **real SDK**: it signs, rotates the verification method, and confirms the historical-signature path still verifies inside TTL
- [x] Observability: emits `agent_did.workflow.handoff_verified` and `agent_did.workflow.handoff_blocked` with `from_did`, `to_did`, `action_class`, `ttl_seconds`, `decision_reason`, `failing_gates` (on block)
- [x] Example under `examples/` showing a multi-executor workflow with at least one verified handoff
- [x] README section in `integrations/microsoft-agent-framework/README.md` linking back to the Public Review thread and crediting the design framing

## Design rule respected

All key-lifecycle logic delegates to SDK central primitives (`AgentIdentity.verify_signature` for current key set, `AgentIdentity.verify_historical_signature` for the rotation race window). The helper never re-implements identity verification — when the spec converges with aeoess and the SDK updates, this verifier inherits the change automatically.

## Validation

```
$ .\.venv-ci-maf\Scripts\python.exe -m pytest tests/ -q
..............................                                           [100%]
30 passed in 1.60s
```

End-to-end example output:

```
Workflow completed. Verified handoffs emitted: 1
  from_did=did:agent:polygon:ff0e9dcceac9...
  action_class=reversible ttl_seconds=300
```

## Review

@haroldmalikfrimpong-ops — requesting your review since the design is yours. Key points worth a second look:

1. The shape of `VerificationBlockedError` (vs. the original sketch).
2. The `on_verification_blocked` callback semantics: `None`-return halts the workflow, any other return is routed downstream via `ctx.send_message(...)`. Reasonable?
3. The key-rotation race: I implemented "inside TTL → accept via historical sig path; past TTL → must verify against current key set". The integration test signs → rotates → re-verifies and confirms both paths.
4. Observability event names + attributes.

If you'd prefer a different module name, default TTLs, or a different exception shape, happy to iterate.
