### PR TITLE
docs: add historical notice to Analisis-criticas documents

### DIFF
--- a/docs/Analisis-criticas/Project-Analysis-Report.md
+++ b/docs/Analisis-criticas/Project-Analysis-Report.md
@@ -1,5 +1,7 @@
 # Agent-DID: Informe de Análisis del Proyecto
 
+> **Historical document** — this analysis reflects the project state as of 2026-03-29 and is not updated as the project evolves. For current status, see [`README.md`](../../README.md) and [`docs/INDEX.md`](../INDEX.md).
+
 **Fecha**: 29 de marzo de 2026
 **Versión**: 1.0
 **Tipo**: Análisis Estratégico y Técnico

--- a/docs/Analisis-criticas/agent-did-due-diligence-2026-03-29.md
+++ b/docs/Analisis-criticas/agent-did-due-diligence-2026-03-29.md
@@ -1,5 +1,7 @@
 # Due diligence técnica y estratégica — Agent-DID
 
+> **Historical document** — this analysis reflects the project state as of 2026-03-29 and is not updated as the project evolves. For current status, see [`README.md`](../../README.md) and [`docs/INDEX.md`](../INDEX.md).
+
 **Proyecto analizado:** `edisonduran/agent-did`  
 **Fecha:** 2026-03-29  
 **Objetivo:** evaluar el proyecto como oportunidad técnica y estratégica, incluyendo comparables, calidad de implementación, riesgos y recomendaciones.


### PR DESCRIPTION
Added historical notice to both documents under docs/Analisis-criticas as requested in Issue #17.

Changes:
- Updated Project-Analysis-Report.md
- Updated agent-did-due-diligence-2026-03-29.md
- No other files modified
