### PR TITLE
docs: clarify assigned issue PR scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,10 @@ The following surfaces are treated as comparatively stable unless a correctness 
 10. Commit with a descriptive message following [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(sdk): add batch DID resolution`).
 11. Open a Pull Request against `master`.
 
+#### Assigned Issues and PR Scope
+
+If an issue is already assigned to another contributor, please coordinate in the issue before opening a competing PR. Maintainers may close PRs that do not match the assigned scope, modify unrelated files or sections, or introduce visible regressions.
+
 ### 3. Improve Documentation
 
 Docs are available in English and Spanish under `docs/`. Improvements to the specification, training materials, or runbooks are always welcome. Tag your issue or PR with `[Docs]`.


### PR DESCRIPTION
## Summary

Adds a short contributor guideline for assigned issues and PR scope.

## Context

After closing an out-of-scope README PR against an already assigned issue, this makes the maintainer expectation explicit: contributors should coordinate before opening a competing PR on an assigned issue, and maintainers may close PRs that drift from the requested scope or introduce visible regressions.

## Validation

- Documentation-only change
- No tests required