### PR TITLE
docs: surface A2A composition contract

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,6 +26,7 @@ This index is the fast path through the repository documentation.
 | [Documentation-Governance.md](Documentation-Governance.md) | Contributors, Reviewers | Stable | Defines canonical sources of truth and live-document update rules. |
 | [DEPRECATION-POLICY.md](DEPRECATION-POLICY.md) | Users, Contributors, Reviewers | Stable | Explains breaking-change and support expectations during Public Review. |
 | [RFC-001-Agent-DID-Specification.md](RFC-001-Agent-DID-Specification.md) | Users, Contributors, Reviewers | Draft | Canonical Agent-DID specification under Public Review. |
+| [RFC-001-A2A-Identity-Composition-Contract.md](RFC-001-A2A-Identity-Composition-Contract.md) | Contributors, Reviewers | Draft | Defines the A2A Agent Card and per-request signing composition contract co-drafted with APS. |
 | [RFC-001-Compliance-Checklist.md](RFC-001-Compliance-Checklist.md) | Contributors, Reviewers | Stable | Tracks RFC conformance claims against implemented behavior. |
 | [RFC-001-Implementation-Backlog.md](RFC-001-Implementation-Backlog.md) | Contributors, Reviewers | Stable | Execution history and remaining implementation work. |
 | [RFC-001-Resolver-HA-Runbook.md](RFC-001-Resolver-HA-Runbook.md) | Contributors, Reviewers | Stable | Operational guidance for resolver high-availability drills. |

--- a/integrations/a2a/README.md
+++ b/integrations/a2a/README.md
@@ -24,6 +24,19 @@ The A2A protocol is **auth-agnostic** — it defines how agents communicate (JSO
 - **Observability** — structured, sanitized event emission for signing, verification, and card generation
 - **Secure Defaults** — sensitive fields redacted, private network targets blocked, extra config fields rejected
 
+## Identity Composition Contract
+
+The canonical A2A identity invariant for this repository is documented in [RFC-001-A2A-Identity-Composition-Contract.md](../../docs/RFC-001-A2A-Identity-Composition-Contract.md), co-drafted with APS during Public Review.
+
+The contract defines how two identity surfaces compose:
+
+- **Identity-at-rest**: the published AgentCard and its DID-published key material.
+- **Identity-in-motion**: the per-request HTTP signature and its `keyid`.
+
+An A2A verifier must treat those surfaces as a single trust boundary: the per-request signing key must compose with the AgentCard and DID document key material, and the signing key must be authorized for the operation context described in §6.3 of the contract.
+
+Current integration behavior publishes DID-enriched AgentCards and signs/verifies A2A requests with Agent-DID HTTP signatures. The stricter SDK-level enforcement of §6.3 verification-relationship binding is tracked in [issue #34](https://github.com/edisonduran/agent-did/issues/34); the umbrella closure work for the composition contract remains tracked in [issue #30](https://github.com/edisonduran/agent-did/issues/30).
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary

Surfaces the A2A identity composition contract in the contributor-facing documentation entry points.

## Changes

- Adds docs/RFC-001-A2A-Identity-Composition-Contract.md to docs/INDEX.md.
- Adds an Identity Composition Contract section to the A2A integration README.
- Links the remaining enforcement work to #34 and the umbrella closure work to #30.

## Validation

- Documentation-only change
- Verified links point to the canonical non-DRAFT document

Closes #42