### PR TITLE
fix: enforce DID key purpose binding

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,6 +77,7 @@ A security policy that doesn't state its threat model is theater. Here is what A
 | T7 | **Cross-SDK divergence enabling parser confusion** | Conformance suite (`npm run conformance:rfc001`) runs against shared fixtures in `fixtures/`. Both TS and Python SDKs are required to agree on every conformance vector. |
 | T8 | **Supply chain tampering of the published packages** | npm and PyPI packages are published from CI through tagged release workflows (`.github/workflows/publish-*.yml`). Manual pipeline runs are auditable in repo history. Provenance (npm provenance, PyPI trusted publishing) is on the hardening roadmap; see §6. |
 | T9 | **Smart contract vulnerabilities in the EVM registry** | Slither + Mythril run in CI via `.github/workflows/contract-audit.yml`. Findings tracked in [`contracts/reports/security/README.md`](contracts/reports/security/README.md) with explicit accepted-noise rules in [`contracts/audit-triage-rules.json`](contracts/audit-triage-rules.json). Current state: 0 actionable, 0 blocking. |
+| T10 | **Key-purpose confusion** where a valid DID key is used outside its intended verification relationship | SDK verification enforces purpose binding: payload and HTTP signatures require `assertionMethod` by default, `keyAgreement` is never accepted for signing, and mismatches surface `key_purpose_violation`. |
 
 ### 3.2 Out of scope (Agent-DID does NOT solve)
 

--- a/docs/Complete-Agent-DID-SDK-Course-EN.md
+++ b/docs/Complete-Agent-DID-SDK-Course-EN.md
@@ -3331,7 +3331,11 @@ The method supports **multiple signatures** in a single request (`sig1`, `sig2`,
 
 ```typescript
 public static async verifySignature(
-  did: string, payload: string, signature: string, keyId?: string
+  did: string,
+  payload: string,
+  signature: string,
+  keyId?: string,
+  requiredPurpose: VerificationRelationship = 'assertionMethod'
 ): Promise<boolean> {
   // 1. Is it revoked? → FAIL immediately
   const isRevoked = await AgentIdentity.registry.isRevoked(did);
@@ -3358,6 +3362,8 @@ public static async verifySignature(
   return false;
 }
 ```
+
+Current SDKs also enforce DID verification-relationship binding before cryptographic verification. For normal agent messages and HTTP signatures the required purpose is `assertionMethod`; if the key is present only under another relationship, especially `keyAgreement`, verification fails with `IdentityCompositionError.reason === 'key_purpose_violation'`.
 
 **Why verify revocation BEFORE resolving?** Two reasons:
 1. **Security**: A revoked DID is a dead identity — it doesn't matter if the signature is mathematically valid

--- a/docs/Complete-Agent-DID-SDK-Course-ES.md
+++ b/docs/Complete-Agent-DID-SDK-Course-ES.md
@@ -3253,7 +3253,11 @@ El método soporta **múltiples firmas** en una sola petición (`sig1`, `sig2`, 
 
 ```typescript
 public static async verifySignature(
-  did: string, payload: string, signature: string, keyId?: string
+  did: string,
+  payload: string,
+  signature: string,
+  keyId?: string,
+  requiredPurpose: VerificationRelationship = 'assertionMethod'
 ): Promise<boolean> {
   // 1. ¿Está revocado? → FAIL inmediatamente
   const isRevoked = await AgentIdentity.registry.isRevoked(did);
@@ -3280,6 +3284,8 @@ public static async verifySignature(
   return false;
 }
 ```
+
+Los SDKs actuales también aplican el binding de relación de verificación DID antes de la verificación criptográfica. Para mensajes normales de agente y firmas HTTP, el propósito requerido es `assertionMethod`; si la clave solo aparece bajo otra relación, especialmente `keyAgreement`, la verificación falla con `IdentityCompositionError.reason === 'key_purpose_violation'`.
 
 **¿Por qué verifica revocación ANTES de resolver?** Dos razones:
 1. **Seguridad**: Un DID revocado es una identidad muerta — no importa si la firma es matemáticamente válida

--- a/docs/DEPRECATION-POLICY.md
+++ b/docs/DEPRECATION-POLICY.md
@@ -71,6 +71,8 @@ In those cases, maintainers will still document:
 - why it changed immediately
 - how to migrate
 
+Public Review example: SDK signature verification now enforces DID verification-relationship binding by default. Agent payload and HTTP signatures require `assertionMethod`, and a key listed only under another relationship such as `keyAgreement` fails with `key_purpose_violation`. Documents that previously placed signing keys only in `authentication` should add the appropriate signing relationship.
+
 ## What Counts as a Breaking Change
 
 The following should be treated as breaking unless explicitly documented otherwise:

--- a/docs/F1-03-LangChain-Integration-Parity-Review-Checklist.md
+++ b/docs/F1-03-LangChain-Integration-Parity-Review-Checklist.md
@@ -33,6 +33,7 @@ Run this checklist when a change affects one or more of the following:
 - [ ] HTTP signing remains opt-in in both packages.
 - [ ] Payload signing remains opt-in in both packages.
 - [ ] Key rotation remains opt-in in both packages.
+- [ ] DID documents used for signing demos bind signing keys to `assertionMethod`, not only `authentication` or `keyAgreement`.
 - [ ] HTTP target validation still rejects invalid schemes, embedded credentials and private or loopback targets by default.
 - [ ] When `allow_private_network_targets` is enabled, `http_security` options are propagated to the SDK's `signHttpRequest` in both packages (or the divergence is documented in the parity matrix).
 
@@ -94,6 +95,7 @@ Parity verification is complete when:
 
 | Date | Change |
 |------|--------|
+| 2026-05-04 | Added parity review coverage for `assertionMethod` binding in signing-capable `did:wba` demo DID documents. |
 | 2026-03-31 | Repository slug updated to `agent-did` and active LangChain TS/Python package references normalized to `@agentdid/*` in README/examples/metadata. No functional changes to the integration surface; parity artifacts refreshed for governance compliance. |
 | 2026-03-23 | Added a canonical walkthrough and a cross-package `did:wba` demo smoke gate so parity review also covers executable demo behavior. |
 | 2026-03-22 | Added explicit parity review gate for integrated `did:wba` demos and refreshed the parity matrix after shipping mirrored LangChain TS/Python demos. |

--- a/docs/F1-03-LangChain-TS-Python-Integration-Parity-Matrix.md
+++ b/docs/F1-03-LangChain-TS-Python-Integration-Parity-Matrix.md
@@ -61,7 +61,7 @@ La parity de integracion se define en cinco dimensiones:
 | Ejemplo base | `agentDidLangChain.example.js` | `agent_did_langchain_example.py` | ✅ | Ambos muestran create_agent/createAgent + tools. |
 | Ejemplo de observabilidad | `agentDidLangChain.observability.example.js` | `agent_did_langchain_observability_example.py` | ✅ | Parity operativa minima lograda. |
 | Receta tipo produccion | `agentDidLangChain.productionRecipe.example.js` | `agent_did_langchain_production_recipe_example.py` | ✅ | Ambos usan guardas de entorno. |
-| Demo integrado `did:wba` | `agentDidLangChain.didWbaDemo.example.js` | `agent_did_langchain_did_wba_demo.py` | ✅ | Ambos muestran runtime `did:wba`, partner remoto `did:wba`, `createAgent`/`create_agent` local y firma HTTP verificable sin credenciales externas. |
+| Demo integrado `did:wba` | `agentDidLangChain.didWbaDemo.example.js` | `agent_did_langchain_did_wba_demo.py` | ✅ | Ambos muestran runtime `did:wba`, partner remoto `did:wba`, `createAgent`/`create_agent` local y firma HTTP verificable sin credenciales externas. Los DID documents de demo declaran las claves de firma en `assertionMethod` para cumplir el binding de relaciones de verificacion del SDK. |
 | Smoke cross-package `did:wba` | `npm run smoke:langchain-didwba` ejecuta el demo JavaScript publicado y valida su contrato JSON. | El mismo comando ejecuta el demo Python publicado y valida su contrato JSON en la misma corrida. | ✅ | Este smoke es gate de parity operativa entre ambos demos, no solo una conveniencia local. |
 | Integracion LangSmith dedicada | `createLangSmithRunTree(...)` + `createLangSmithEventHandler(...)` | Adapter dedicado disponible | ✅ | Ambos paquetes exponen adaptador dedicado sin cambiar la factory principal. |
 | Profundidad de suite automatizada | tests funcionales, seguridad y observabilidad | tests funcionales, seguridad, observabilidad y modulos internos | ⚠️ | Python sigue mas granular. |
@@ -127,6 +127,7 @@ La parity de integraciones LangChain TS vs Python se considera mantenida cuando:
 
 | Fecha | Cambio |
 |-------|--------|
+| 2026-05-04 | Los demos integrados `did:wba` TS/Python ahora declaran `assertionMethod` en los DID documents usados para firma HTTP, manteniendo parity con el enforcement de key purpose binding del SDK. |
 | 2026-03-31 | Rename del repositorio a `agent-did` y normalizacion de metadata publica para LangChain TS/Python: URLs de GitHub, referencias de instalacion y ejemplos activos alineados con `@agentdid/sdk` y `@agentdid/langchain`. Sin cambios en la API publica ni en la parity funcional. |
 | 2026-03-22 | Se agregaron demos integrados `did:wba` equivalentes para LangChain TS y Python, junto con cobertura automatizada y referencias en README. La parity de ejemplos operativos se mantiene. |
 | 2026-03-22 | Licencia del repositorio migrada de MIT a Apache-2.0. Actualizado `package.json` (langchain TS) y `pyproject.toml` (langchain-python). Sin cambios funcionales en la superficie de integración. |

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -58,6 +58,8 @@ Agent-DID closes that gap with two mechanisms:
 - **Framework abstractions** that inject identity into the agent's execution chain without extra developer code.
 - **Ed25519 by default** — a fast, compact, and widely trusted cryptographic primitive for high-frequency signing environments, with no confusing options or misconfigurable parameters.
 
+That simplicity still has to be precise: a valid key is not automatically valid for every action. Agent-DID verification binds keys to their DID verification relationship, so signing flows use signing-capable purposes such as `assertionMethod` and never accept `keyAgreement` as a shortcut.
+
 ---
 
 ## The Vision

--- a/docs/RFC-001-Agent-DID-Specification.md
+++ b/docs/RFC-001-Agent-DID-Specification.md
@@ -152,8 +152,17 @@ graph TD
 
 1. Consumer obtains `Signature-Agent` or the issuer's DID.
 2. Resolves DID via universal resolver (with fallback/failover in production profile).
-3. Verifies signature with `verificationMethod`.
-4. Verifies non-revoked state in registry.
+3. Verifies the signing key is authorized for the required DID verification relationship.
+4. Verifies signature with `verificationMethod`.
+5. Verifies non-revoked state in registry.
+
+#### 6.2.1 Verification Relationship Binding
+
+Signature verification is not complete when the public key is merely present in `verificationMethod`. A verifier MUST confirm that the key ID is also listed in the DID verification relationship required by the action being verified.
+
+The default signing purpose for Agent-DID payloads and HTTP signatures is `assertionMethod`. Other signing flows MAY require `authentication`, `capabilityDelegation`, or `capabilityInvocation`. A key listed only under `keyAgreement` MUST NOT be accepted for signing or proof verification.
+
+When a key exists in the DID document but is not authorized for the requested purpose, SDKs MUST raise or surface a deterministic `key_purpose_violation` reason and, where practical, include the relationships where the key was found.
 
 ### 6.3 Evolution
 
@@ -185,6 +194,7 @@ The reference SDK (TypeScript/Python) must expose at minimum:
 4. `resolve(did)`
 5. `verifySignature(did, payload, signature)`
 6. `revokeDid(did)`
+7. `assertKeyPurpose(keyId, didDoc, requiredPurpose)` / `assert_key_purpose(...)`
 
 ### 7.1 Reference Contract/Registry (EVM)
 
@@ -218,6 +228,7 @@ Current fixture reference:
 | HTTP Signing (6.5) | `signHttpRequest(params)` |
 | DID Resolution (6.2) | `AgentIdentity.resolve(did)` |
 | Signature Verification (6.2) | `AgentIdentity.verifySignature(...)` and `verifyHttpRequestSignature(...)` |
+| Verification Relationship Binding (6.2.1) | `assertKeyPurpose(...)` / `assert_key_purpose(...)`, default `assertionMethod` |
 | Historical Signature Verification (6.2b) | `AgentIdentity.verifyHistoricalSignature(did, payload, signature, keyId)` |
 | Document Evolution (6.3) | `updateDidDocument(did, patch)` |
 | Key Rotation (8.2) | `rotateVerificationMethod(did)` — marks old keys as `deactivated` |
@@ -247,6 +258,7 @@ Recommended full validation command:
 - **DID not found:** resolution fails (`DID not found` or resolver equivalent).
 - **DID revoked:** `resolve`/`verifySignature` must fail or return invalid.
 - **Invalid signature/tampered payload:** verification returns `false`.
+- **Wrong key purpose:** verification raises or surfaces `key_purpose_violation` with the relationships where the key was found.
 - **Incompatible `Signature-Input`:** HTTP verification returns `false`.
 - **Unresolvable `documentRef`:** resolver attempts failover; if all fail, error.
 

--- a/docs/RFC-001-Agent-DID-Specification.md
+++ b/docs/RFC-001-Agent-DID-Specification.md
@@ -164,6 +164,20 @@ The default signing purpose for Agent-DID payloads and HTTP signatures is `asser
 
 When a key exists in the DID document but is not authorized for the requested purpose, SDKs MUST raise or surface a deterministic `key_purpose_violation` reason and, where practical, include the relationships where the key was found.
 
+#### 6.2.1.1 Identity Composition Error Shape
+
+To enable cross-implementation interop and programmatic verifiers, conforming SDKs MUST expose identity-composition errors with the following normative shape:
+
+- `reason` (REQUIRED): one of the deterministic identity-composition reasons: `key_purpose_violation`, `rotation_window_closed`, `emergency_revoked`, `tampered`.
+- `keyId` / `key_id` (REQUIRED): verification method identifier that triggered the failure (empty string when not applicable).
+- `requiredPurpose` / `required_purpose` (REQUIRED): DID verification relationship the action required.
+- `foundIn` / `found_in` (REQUIRED): verification relationships where the key was actually listed (MAY be empty).
+- `did` (OPTIONAL): subject DID, included when known.
+
+These fields MUST be exposed as direct properties of the error object using the language-idiomatic naming above. Implementations MAY additionally mirror the same fields under a `context` namespace (for example `error.context.keyId`) to interoperate with verifiers that expect a nested error envelope, provided the direct properties remain authoritative. Mirrored values MUST be byte-equal to the direct properties.
+
+The `assertKeyPurpose` helper is a membership-only predicate over the requested verification relationship and MUST NOT short-circuit on `keyAgreement`. The signing-purpose policy that rejects `keyAgreement` for signing flows lives in `assertSigningPurpose` (or the equivalent entry point) and is invoked by the SDK before `assertKeyPurpose` during signature verification.
+
 ### 6.3 Evolution
 
 1. The DID remains stable.

--- a/integrations/langchain-python/examples/agent_did_langchain_did_wba_demo.py
+++ b/integrations/langchain-python/examples/agent_did_langchain_did_wba_demo.py
@@ -70,6 +70,7 @@ def _build_did_document(
                 }
             ],
             "authentication": [f"{did}#key-1"],
+            "assertionMethod": [f"{did}#key-1"],
         }
     )
 

--- a/integrations/langchain-python/tests/test_did_wba_demo.py
+++ b/integrations/langchain-python/tests/test_did_wba_demo.py
@@ -55,6 +55,7 @@ def _build_did_document(
                 }
             ],
             "authentication": [f"{did}#key-1"],
+            "assertionMethod": [f"{did}#key-1"],
         }
     )
 

--- a/integrations/langchain/examples/agentDidLangChain.didWbaDemo.example.js
+++ b/integrations/langchain/examples/agentDidLangChain.didWbaDemo.example.js
@@ -37,6 +37,7 @@ function buildRuntimeDidWbaDocument(runtimeIdentity) {
       },
     ],
     authentication: [`${ACTIVE_DID}#key-1`],
+    assertionMethod: [`${ACTIVE_DID}#key-1`],
   };
 }
 
@@ -64,6 +65,7 @@ function buildPartnerDocument() {
       },
     ],
     authentication: [`${PARTNER_DID}#key-1`],
+    assertionMethod: [`${PARTNER_DID}#key-1`],
   };
 }
 

--- a/integrations/langchain/tests/agentDidLangChain.didWbaDemo.test.js
+++ b/integrations/langchain/tests/agentDidLangChain.didWbaDemo.test.js
@@ -36,6 +36,7 @@ function buildRuntimeDidWbaDocument(runtimeIdentity) {
       },
     ],
     authentication: [`${ACTIVE_DID}#key-1`],
+    assertionMethod: [`${ACTIVE_DID}#key-1`],
   };
 }
 
@@ -63,6 +64,7 @@ function buildPartnerDocument() {
       },
     ],
     authentication: [`${PARTNER_DID}#key-1`],
+    assertionMethod: [`${PARTNER_DID}#key-1`],
   };
 }
 

--- a/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/handoff.py
+++ b/integrations/microsoft-agent-framework/src/agent_did_microsoft_agent_framework/handoff.py
@@ -33,7 +33,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from agent_did_sdk import AgentIdentity
+from agent_did_sdk import AgentIdentity, IdentityCompositionError
 from agent_framework import FunctionExecutor, WorkflowContext
 
 from .observability import AgentDidObserver
@@ -297,21 +297,51 @@ async def _run_signature_verification(
     staleness = max(0.0, ctx.now() - message.signed_at)
 
     if staleness > ctx.ttl_seconds:
-        valid = await ctx.verify_signature(
-            message.did, payload_str, message.signature, message.key_id
-        )
+        valid = await _verify_signature_with_purpose(ctx, message, payload_str)
         return bool(valid), False, staleness, "key_lifecycle"
 
-    valid = await ctx.verify_signature(
-        message.did, payload_str, message.signature, message.key_id
-    )
+    valid = await _verify_signature_with_purpose(ctx, message, payload_str)
     used_historical = False
     if not valid and message.key_id:
-        valid = await ctx.verify_historical_signature(
-            message.did, payload_str, message.signature, message.key_id
-        )
+        valid = await _verify_historical_signature_with_purpose(ctx, message, payload_str)
         used_historical = bool(valid)
     return bool(valid), used_historical, staleness, "signature"
+
+
+async def _verify_signature_with_purpose(
+    ctx: _VerifierContext,
+    message: SignedHandoffMessage,
+    payload_str: str,
+) -> bool:
+    try:
+        valid = await ctx.verify_signature(
+            message.did,
+            payload_str,
+            message.signature,
+            message.key_id,
+            required_purpose="assertionMethod",
+        )
+        return bool(valid)
+    except IdentityCompositionError:
+        return False
+
+
+async def _verify_historical_signature_with_purpose(
+    ctx: _VerifierContext,
+    message: SignedHandoffMessage,
+    payload_str: str,
+) -> bool:
+    try:
+        valid = await ctx.verify_historical_signature(
+            message.did,
+            payload_str,
+            message.signature,
+            message.key_id,
+            required_purpose="assertionMethod",
+        )
+        return bool(valid)
+    except IdentityCompositionError:
+        return False
 
 
 def build_handoff_verifier_executor(

--- a/integrations/microsoft-agent-framework/tests/test_verified_handoff.py
+++ b/integrations/microsoft-agent-framework/tests/test_verified_handoff.py
@@ -201,6 +201,42 @@ def test_invalid_signature_blocked() -> None:
     assert exc.value.failing_gates == ["signature"]
 
 
+def test_signature_verification_requests_assertion_method_purpose() -> None:
+    observer, _events = _make_observer()
+    calls: list[tuple[str, dict]] = []
+
+    async def verify_signature(*_args, **kwargs):
+        calls.append(("current", kwargs))
+        return False
+
+    async def verify_historical_signature(*_args, **kwargs):
+        calls.append(("historical", kwargs))
+        return False
+
+    verifier = build_handoff_verifier_function(
+        _ctx(
+            observer=observer,
+            verify_signature=verify_signature,
+            verify_historical_signature=verify_historical_signature,
+        )
+    )
+    msg = SignedHandoffMessage(
+        payload="x",
+        did="did:wba:agent",
+        signature="00",
+        signed_at=time.time(),
+        key_id="did:wba:agent#key-1",
+    )
+
+    with pytest.raises(VerificationBlockedError):
+        _run_verifier(verifier, msg)
+
+    assert calls == [
+        ("current", {"required_purpose": "assertionMethod"}),
+        ("historical", {"required_purpose": "assertionMethod"}),
+    ]
+
+
 def test_expired_ttl_with_failing_reverify_blocked_as_key_lifecycle() -> None:
     observer, _events = _make_observer()
     verifier = build_handoff_verifier_function(

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -65,6 +65,7 @@ asyncio.run(main())
 | Sign messages (Ed25519) | `identity.sign_message(payload, key)` | ✅ |
 | Sign HTTP requests (Bot Auth) | `identity.sign_http_request(params)` | ✅ |
 | Verify message signatures | `AgentIdentity.verify_signature(did, payload, sig)` | ✅ |
+| Enforce key purpose binding | `assert_key_purpose(key_id, did_doc, purpose)` | ✅ |
 | Verify HTTP signatures | `AgentIdentity.verify_http_request_signature(params)` | ✅ |
 | Resolve DID → document | `AgentIdentity.resolve(did)` | ✅ |
 | Revoke DID | `AgentIdentity.revoke_did(did)` | ✅ |
@@ -73,6 +74,8 @@ asyncio.run(main())
 | Document history/audit | `AgentIdentity.get_document_history(did)` | ✅ |
 | EVM registry adapter | `EvmAgentRegistry` + `Web3AgentRegistryContractClient` | ✅ |
 | Universal resolver (HTTP/RPC/IPFS) | `UniversalResolverClient` | ✅ |
+
+By default, `verify_signature` and HTTP signature verification require the signing key to be listed under `assertionMethod` in the DID document. Passing a key that exists only under another relationship, including `keyAgreement`, raises `IdentityCompositionError` with reason `key_purpose_violation`.
 
 ## Modules
 

--- a/sdk-python/scripts/conformance_rfc001.py
+++ b/sdk-python/scripts/conformance_rfc001.py
@@ -149,6 +149,8 @@ async def evaluate_lifecycle_controls(
         and updated.agent_metadata.version == "2.0.0"
         and rotated.verification_method_id.endswith("#key-2")
         and rotated.document.authentication == [rotated.verification_method_id]
+        and rotated.document.assertion_method is not None
+        and rotated.verification_method_id in rotated.document.assertion_method
     )
     return [CheckResult("MUST-10", "PASS" if must_10_ok else "FAIL")], rotated, [], record_after_rotation
 
@@ -220,6 +222,7 @@ def build_interop_document(interop_vectors: dict[str, object]) -> AgentDIDDocume
             },
             "verificationMethod": [verification_method],
             "authentication": [verification_method["id"]],
+            "assertionMethod": [verification_method["id"]],
         }
     )
 

--- a/sdk-python/src/agent_did_sdk/__init__.py
+++ b/sdk-python/src/agent_did_sdk/__init__.py
@@ -10,6 +10,15 @@ from .core.identity import (
     ProductionJsonRpcResolverProfileConfig,
     ProductionResolverProfileConfig,
 )
+from .core.identity_composition import (
+    DID_VERIFICATION_RELATIONSHIPS,
+    SIGNING_VERIFICATION_PURPOSES,
+    IdentityCompositionError,
+    assert_key_purpose,
+    assert_signing_purpose,
+    get_key_relationships,
+    get_relationship_key_ids,
+)
 from .core.signer import AgentSigner, LocalKeySigner
 from .core.time_utils import (
     is_unix_timestamp_string,
@@ -24,11 +33,14 @@ from .core.types import (
     AgentMetadata,
     CreateAgentParams,
     CreateAgentResult,
+    IdentityCompositionErrorReason,
     RotateVerificationMethodResult,
     SignHttpRequestParams,
+    SigningVerificationPurpose,
     UpdateAgentDocumentParams,
     VerifiableCredentialLink,
     VerificationMethod,
+    VerificationRelationship,
     VerifyHttpRequestSignatureParams,
 )
 from .crypto.hash import format_hash_uri, generate_agent_metadata_hash, hash_payload
@@ -57,6 +69,9 @@ __all__ = [
     "VerifiableCredentialLink",
     "VerificationMethod",
     "AgentDIDDocument",
+    "VerificationRelationship",
+    "SigningVerificationPurpose",
+    "IdentityCompositionErrorReason",
     "CreateAgentParams",
     "CreateAgentResult",
     "UpdateAgentDocumentParams",
@@ -65,6 +80,14 @@ __all__ = [
     "VerifyHttpRequestSignatureParams",
     "AgentDocumentHistoryAction",
     "AgentDocumentHistoryEntry",
+    # Identity composition
+    "IdentityCompositionError",
+    "DID_VERIFICATION_RELATIONSHIPS",
+    "SIGNING_VERIFICATION_PURPOSES",
+    "assert_key_purpose",
+    "assert_signing_purpose",
+    "get_key_relationships",
+    "get_relationship_key_ids",
     # Core signer
     "AgentSigner",
     "LocalKeySigner",

--- a/sdk-python/src/agent_did_sdk/core/__init__.py
+++ b/sdk-python/src/agent_did_sdk/core/__init__.py
@@ -1,0 +1,21 @@
+"""Core Agent-DID SDK helpers."""
+
+from .identity_composition import (
+    DID_VERIFICATION_RELATIONSHIPS,
+    SIGNING_VERIFICATION_PURPOSES,
+    IdentityCompositionError,
+    assert_key_purpose,
+    assert_signing_purpose,
+    get_key_relationships,
+    get_relationship_key_ids,
+)
+
+__all__ = [
+    "IdentityCompositionError",
+    "DID_VERIFICATION_RELATIONSHIPS",
+    "SIGNING_VERIFICATION_PURPOSES",
+    "assert_key_purpose",
+    "assert_signing_purpose",
+    "get_key_relationships",
+    "get_relationship_key_ids",
+]

--- a/sdk-python/src/agent_did_sdk/core/identity.py
+++ b/sdk-python/src/agent_did_sdk/core/identity.py
@@ -252,8 +252,8 @@ class AgentIdentity:
         if expected_digest != digest_header:
             return False
 
-        parsed_inputs = cls._parse_http_signature_input_dictionary(sig_input_header)  # type: ignore[arg-type]
-        parsed_sigs = cls._parse_http_signature_dictionary(sig_header)  # type: ignore[arg-type]
+        parsed_inputs = cls._parse_http_signature_input_dictionary(sig_input_header)
+        parsed_sigs = cls._parse_http_signature_dictionary(sig_header)
 
         now = int(time.time())
         max_skew = params.max_created_skew_seconds if params.max_created_skew_seconds is not None else 300

--- a/sdk-python/src/agent_did_sdk/core/identity.py
+++ b/sdk-python/src/agent_did_sdk/core/identity.py
@@ -33,6 +33,7 @@ from ..resolver.types import (
 )
 from ..resolver.universal import UniversalResolverClient
 from .http_security import validate_http_target
+from .identity_composition import assert_key_purpose, assert_signing_purpose, get_relationship_key_ids
 from .signer import AgentSigner
 from .time_utils import normalize_timestamp_to_iso
 from .types import (
@@ -45,6 +46,7 @@ from .types import (
     SignHttpRequestParams,
     UpdateAgentDocumentParams,
     VerificationMethod,
+    VerificationRelationship,
     VerifyHttpRequestSignatureParams,
 )
 
@@ -162,6 +164,7 @@ class AgentIdentity:
                 },
                 "verificationMethod": [vm.model_dump(by_alias=True, exclude_none=True)],
                 "authentication": [verification_method_id],
+                "assertionMethod": [verification_method_id],
             }
         )
 
@@ -239,6 +242,11 @@ class AgentIdentity:
 
         if not all([sig_header, sig_input_header, sig_agent, date_header, digest_header]):
             return False
+        assert sig_header is not None
+        assert sig_input_header is not None
+        assert sig_agent is not None
+        assert date_header is not None
+        assert digest_header is not None
 
         expected_digest = cls._compute_content_digest(params.body)
         if expected_digest != digest_header:
@@ -294,32 +302,50 @@ class AgentIdentity:
 
             # Rebuild signature base including nonce
             sig_base = cls._build_http_signature_base(
-                method=params.method, url=params.url, date_header=date_header,  # type: ignore[arg-type]
+                method=params.method, url=params.url, date_header=date_header,
                 content_digest=digest_header, nonce=nonce_header,
             )
 
             sig_hex = bytes(base64.b64decode(sig_b64)).hex()
-            is_valid = await cls.verify_signature(sig_agent, sig_base, sig_hex, key_id)  # type: ignore[arg-type]
+            is_valid = await cls.verify_signature(
+                sig_agent,
+                sig_base,
+                sig_hex,
+                key_id,
+                required_purpose="assertionMethod",
+            )
             if is_valid:
                 return True
 
         return False
 
     @classmethod
-    async def verify_signature(cls, did: str, payload: str, signature: str, key_id: str | None = None) -> bool:
+    async def verify_signature(
+        cls,
+        did: str,
+        payload: str,
+        signature: str,
+        key_id: str | None = None,
+        required_purpose: VerificationRelationship = "assertionMethod",
+    ) -> bool:
         """Verify that *signature* was produced by *did* for *payload*."""
         is_revoked = await cls._registry.is_revoked(did)
         if is_revoked:
             return False
 
         doc = await cls.resolve(did)
+        assert_signing_purpose(required_purpose, doc, key_id or "")
+        if key_id is not None:
+            assert_key_purpose(key_id, doc, required_purpose)
+
         message_bytes = payload.encode("utf-8")
         sig_bytes = bytes.fromhex(signature)
 
-        active_ids = set(doc.authentication or [])
+        active_ids = set(get_relationship_key_ids(doc, required_purpose))
         candidates = [
             m for m in doc.verification_method
             if m.public_key_multibase
+            and not m.deactivated
             and (m.id == key_id and m.id in active_ids if key_id else m.id in active_ids)
         ]
 
@@ -338,7 +364,12 @@ class AgentIdentity:
 
     @classmethod
     async def verify_historical_signature(
-        cls, did: str, payload: str, signature: str, key_id: str
+        cls,
+        did: str,
+        payload: str,
+        signature: str,
+        key_id: str,
+        required_purpose: VerificationRelationship = "assertionMethod",
     ) -> bool:
         """Verify a historical signature against any key (including deactivated) in the DID document."""
         is_revoked = await cls._registry.is_revoked(did)
@@ -346,6 +377,9 @@ class AgentIdentity:
             return False
 
         doc = await cls.resolve(did)
+        assert_signing_purpose(required_purpose, doc, key_id)
+        assert_key_purpose(key_id, doc, required_purpose)
+
         message_bytes = payload.encode("utf-8")
         sig_bytes = bytes.fromhex(signature)
 
@@ -433,6 +467,10 @@ class AgentIdentity:
                     for vm in existing.verification_method
                 ],
                 "authentication": existing.authentication,
+                "assertionMethod": existing.assertion_method,
+                "capabilityDelegation": existing.capability_delegation,
+                "capabilityInvocation": existing.capability_invocation,
+                "keyAgreement": existing.key_agreement,
             }
         )
 
@@ -484,6 +522,10 @@ class AgentIdentity:
                 "agentMetadata": existing.agent_metadata.model_dump(by_alias=True, exclude_none=True),
                 "verificationMethod": all_vms,
                 "authentication": [vm_id],
+                "assertionMethod": list(dict.fromkeys([*(existing.assertion_method or []), vm_id])),
+                "capabilityDelegation": existing.capability_delegation,
+                "capabilityInvocation": existing.capability_invocation,
+                "keyAgreement": existing.key_agreement,
             }
         )
 

--- a/sdk-python/src/agent_did_sdk/core/identity_composition.py
+++ b/sdk-python/src/agent_did_sdk/core/identity_composition.py
@@ -1,0 +1,105 @@
+"""Identity-composition helpers for DID verification relationships."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .types import (
+    AgentDIDDocument,
+    IdentityCompositionErrorReason,
+    SigningVerificationPurpose,
+    VerificationRelationship,
+)
+
+DID_VERIFICATION_RELATIONSHIPS: tuple[VerificationRelationship, ...] = (
+    "authentication",
+    "assertionMethod",
+    "capabilityDelegation",
+    "capabilityInvocation",
+    "keyAgreement",
+)
+
+SIGNING_VERIFICATION_PURPOSES: tuple[SigningVerificationPurpose, ...] = (
+    "authentication",
+    "assertionMethod",
+    "capabilityDelegation",
+    "capabilityInvocation",
+)
+
+
+class IdentityCompositionError(ValueError):
+    """Raised when a key is not authorized for the requested DID relationship."""
+
+    def __init__(
+        self,
+        reason: IdentityCompositionErrorReason,
+        *,
+        key_id: str,
+        required_purpose: VerificationRelationship,
+        found_in: Sequence[VerificationRelationship],
+        did: str | None = None,
+    ) -> None:
+        self.reason = reason
+        self.did = did
+        self.key_id = key_id
+        self.required_purpose = required_purpose
+        self.found_in = list(found_in)
+        super().__init__(
+            f"Verification method {key_id or '<unspecified>'} is not authorized for {required_purpose}"
+        )
+
+
+def get_relationship_key_ids(
+    did_doc: AgentDIDDocument,
+    relationship: VerificationRelationship,
+) -> list[str]:
+    if relationship == "authentication":
+        return did_doc.authentication or []
+    if relationship == "assertionMethod":
+        return did_doc.assertion_method or []
+    if relationship == "capabilityDelegation":
+        return did_doc.capability_delegation or []
+    if relationship == "capabilityInvocation":
+        return did_doc.capability_invocation or []
+    return did_doc.key_agreement or []
+
+
+def get_key_relationships(key_id: str, did_doc: AgentDIDDocument) -> list[VerificationRelationship]:
+    return [
+        relationship
+        for relationship in DID_VERIFICATION_RELATIONSHIPS
+        if key_id in get_relationship_key_ids(did_doc, relationship)
+    ]
+
+
+def assert_key_purpose(
+    key_id: str,
+    did_doc: AgentDIDDocument,
+    required_purpose: VerificationRelationship,
+) -> None:
+    found_in = get_key_relationships(key_id, did_doc)
+    key_ids_for_purpose = get_relationship_key_ids(did_doc, required_purpose)
+
+    if required_purpose == "keyAgreement" or key_id not in key_ids_for_purpose:
+        raise IdentityCompositionError(
+            "key_purpose_violation",
+            did=did_doc.id,
+            key_id=key_id,
+            required_purpose=required_purpose,
+            found_in=found_in,
+        )
+
+
+def assert_signing_purpose(
+    required_purpose: VerificationRelationship,
+    did_doc: AgentDIDDocument,
+    key_id: str = "",
+) -> None:
+    if required_purpose == "keyAgreement":
+        raise IdentityCompositionError(
+            "key_purpose_violation",
+            did=did_doc.id,
+            key_id=key_id,
+            required_purpose=required_purpose,
+            found_in=get_key_relationships(key_id, did_doc) if key_id else [],
+        )

--- a/sdk-python/src/agent_did_sdk/core/identity_composition.py
+++ b/sdk-python/src/agent_did_sdk/core/identity_composition.py
@@ -80,7 +80,8 @@ def assert_key_purpose(
     found_in = get_key_relationships(key_id, did_doc)
     key_ids_for_purpose = get_relationship_key_ids(did_doc, required_purpose)
 
-    if required_purpose == "keyAgreement" or key_id not in key_ids_for_purpose:
+    # Membership-only predicate per RFC-001 §6.2.1; signing-purpose policy lives in assert_signing_purpose.
+    if key_id not in key_ids_for_purpose:
         raise IdentityCompositionError(
             "key_purpose_violation",
             did=did_doc.id,

--- a/sdk-python/src/agent_did_sdk/core/types.py
+++ b/sdk-python/src/agent_did_sdk/core/types.py
@@ -60,6 +60,10 @@ class AgentDIDDocument(BaseModel):
     )
     verification_method: list[VerificationMethod] = Field(alias="verificationMethod")
     authentication: list[str]
+    assertion_method: list[str] | None = Field(default=None, alias="assertionMethod")
+    capability_delegation: list[str] | None = Field(default=None, alias="capabilityDelegation")
+    capability_invocation: list[str] | None = Field(default=None, alias="capabilityInvocation")
+    key_agreement: list[str] | None = Field(default=None, alias="keyAgreement")
 
     def model_dump_jsonld(self) -> dict[str, object]:
         """Serialize using JSON-LD aliases, dropping ``None`` values."""
@@ -139,6 +143,20 @@ class VerifyHttpRequestSignatureParams(BaseModel):
 # ---------------------------------------------------------------------------
 
 AgentDocumentHistoryAction = Literal["created", "updated", "rotated-key", "revoked"]
+VerificationRelationship = Literal[
+    "authentication",
+    "assertionMethod",
+    "capabilityDelegation",
+    "capabilityInvocation",
+    "keyAgreement",
+]
+SigningVerificationPurpose = Literal[
+    "authentication",
+    "assertionMethod",
+    "capabilityDelegation",
+    "capabilityInvocation",
+]
+IdentityCompositionErrorReason = Literal["key_purpose_violation"]
 
 
 class AgentDocumentHistoryEntry(BaseModel):

--- a/sdk-python/src/agent_did_sdk/core/types.py
+++ b/sdk-python/src/agent_did_sdk/core/types.py
@@ -156,7 +156,12 @@ SigningVerificationPurpose = Literal[
     "capabilityDelegation",
     "capabilityInvocation",
 ]
-IdentityCompositionErrorReason = Literal["key_purpose_violation"]
+IdentityCompositionErrorReason = Literal[
+    "key_purpose_violation",
+    "rotation_window_closed",
+    "emergency_revoked",
+    "tampered",
+]
 
 
 class AgentDocumentHistoryEntry(BaseModel):

--- a/sdk-python/tests/test_identity.py
+++ b/sdk-python/tests/test_identity.py
@@ -7,12 +7,14 @@ import pytest
 
 from agent_did_sdk import InMemoryAgentRegistry, ProductionHttpResolverProfileConfig
 from agent_did_sdk.core.identity import AgentIdentity, AgentIdentityConfig
+from agent_did_sdk.core.identity_composition import IdentityCompositionError, assert_key_purpose
 from agent_did_sdk.core.types import (
     CreateAgentParams,
     SignHttpRequestParams,
     UpdateAgentDocumentParams,
     VerifyHttpRequestSignatureParams,
 )
+from agent_did_sdk.resolver.in_memory import InMemoryDIDResolver
 
 
 @pytest.fixture()
@@ -36,6 +38,7 @@ class TestAgentIdentityCreate:
         assert doc.updated.endswith("Z")
         assert len(doc.verification_method) == 1
         assert doc.verification_method[0].public_key_multibase is not None
+        assert doc.assertion_method == [doc.verification_method[0].id]
         assert len(result.agent_private_key) == 64  # 32 bytes hex
 
     async def test_create_with_all_params(self, identity: AgentIdentity) -> None:
@@ -95,6 +98,84 @@ class TestAgentIdentitySignVerify:
         await AgentIdentity.revoke_did(result.document.id)
         is_valid = await AgentIdentity.verify_signature(result.document.id, "data", sig)
         assert is_valid is False
+
+    async def test_assert_key_purpose_reports_found_relationships(self, identity: AgentIdentity) -> None:
+        result = await identity.create(CreateAgentParams(
+            name="PurposeHelper", core_model="m", system_prompt="p",
+        ))
+        key_id = result.document.verification_method[0].id
+        misbound_doc = result.document.model_copy(
+            update={"authentication": [], "assertion_method": [], "key_agreement": [key_id]},
+            deep=True,
+        )
+
+        with pytest.raises(IdentityCompositionError) as exc:
+            assert_key_purpose(key_id, misbound_doc, "assertionMethod")
+
+        assert exc.value.reason == "key_purpose_violation"
+        assert exc.value.key_id == key_id
+        assert exc.value.required_purpose == "assertionMethod"
+        assert exc.value.found_in == ["keyAgreement"]
+
+    async def test_verify_rejects_key_outside_assertion_method(self, identity: AgentIdentity) -> None:
+        result = await identity.create(CreateAgentParams(
+            name="PurposeVerifier", core_model="m", system_prompt="p",
+        ))
+        key_id = result.document.verification_method[0].id
+        payload = "approve:purpose:1"
+        signature = await identity.sign_message(payload, result.agent_private_key)
+        misbound_doc = result.document.model_copy(
+            update={"authentication": [], "assertion_method": [], "key_agreement": [key_id]},
+            deep=True,
+        )
+
+        resolver = InMemoryDIDResolver()
+        resolver.register_document(misbound_doc)
+        AgentIdentity.set_resolver(resolver)
+        AgentIdentity.set_registry(InMemoryAgentRegistry())
+
+        with pytest.raises(IdentityCompositionError) as exc:
+            await AgentIdentity.verify_signature(result.document.id, payload, signature, key_id)
+
+        assert exc.value.reason == "key_purpose_violation"
+        assert exc.value.key_id == key_id
+        assert exc.value.required_purpose == "assertionMethod"
+        assert exc.value.found_in == ["keyAgreement"]
+
+    async def test_verify_rejects_key_agreement_as_signing_purpose(self, identity: AgentIdentity) -> None:
+        result = await identity.create(CreateAgentParams(
+            name="KeyAgreement", core_model="m", system_prompt="p",
+        ))
+        key_id = result.document.verification_method[0].id
+        payload = "approve:key-agreement:1"
+        signature = await identity.sign_message(payload, result.agent_private_key)
+
+        with pytest.raises(IdentityCompositionError) as exc:
+            await AgentIdentity.verify_signature(
+                result.document.id,
+                payload,
+                signature,
+                key_id,
+                required_purpose="keyAgreement",
+            )
+
+        assert exc.value.reason == "key_purpose_violation"
+        assert exc.value.required_purpose == "keyAgreement"
+
+    async def test_verify_rejects_unknown_key_with_key_purpose_violation(self, identity: AgentIdentity) -> None:
+        result = await identity.create(CreateAgentParams(
+            name="UnknownPurpose", core_model="m", system_prompt="p",
+        ))
+        payload = "approve:unknown-key:1"
+        signature = await identity.sign_message(payload, result.agent_private_key)
+        unknown_key_id = f"{result.document.id}#key-999"
+
+        with pytest.raises(IdentityCompositionError) as exc:
+            await AgentIdentity.verify_signature(result.document.id, payload, signature, unknown_key_id)
+
+        assert exc.value.reason == "key_purpose_violation"
+        assert exc.value.key_id == unknown_key_id
+        assert exc.value.found_in == []
 
 
 class TestAgentIdentityHttpSignature:
@@ -296,6 +377,10 @@ class TestAgentIdentityRotateKey:
         assert rotated.verification_method_id.endswith("#key-2")
         assert len(rotated.document.verification_method) == 2
         assert rotated.document.authentication == [rotated.verification_method_id]
+        assert rotated.document.assertion_method == [
+            f"{result.document.id}#key-1",
+            rotated.verification_method_id,
+        ]
 
     async def test_rotate_twice(self, identity: AgentIdentity) -> None:
         result = await identity.create(CreateAgentParams(
@@ -361,10 +446,12 @@ class TestAgentIdentityRotateKey:
             name="UnknownKey", core_model="m", system_prompt="p",
         ))
         fake_sig = "00" * 64
-        valid = await AgentIdentity.verify_historical_signature(
-            result.document.id, "payload", fake_sig, f"{result.document.id}#key-999",
-        )
-        assert valid is False
+        with pytest.raises(IdentityCompositionError) as exc:
+            await AgentIdentity.verify_historical_signature(
+                result.document.id, "payload", fake_sig, f"{result.document.id}#key-999",
+            )
+        assert exc.value.reason == "key_purpose_violation"
+        assert exc.value.found_in == []
 
 
 class TestSignerAbstraction:

--- a/sdk-python/tests/test_identity.py
+++ b/sdk-python/tests/test_identity.py
@@ -7,7 +7,11 @@ import pytest
 
 from agent_did_sdk import InMemoryAgentRegistry, ProductionHttpResolverProfileConfig
 from agent_did_sdk.core.identity import AgentIdentity, AgentIdentityConfig
-from agent_did_sdk.core.identity_composition import IdentityCompositionError, assert_key_purpose
+from agent_did_sdk.core.identity_composition import (
+    IdentityCompositionError,
+    assert_key_purpose,
+    assert_signing_purpose,
+)
 from agent_did_sdk.core.types import (
     CreateAgentParams,
     SignHttpRequestParams,
@@ -176,6 +180,25 @@ class TestAgentIdentitySignVerify:
         assert exc.value.reason == "key_purpose_violation"
         assert exc.value.key_id == unknown_key_id
         assert exc.value.found_in == []
+
+    async def test_assert_key_purpose_accepts_key_agreement_membership(self, identity: AgentIdentity) -> None:
+        result = await identity.create(CreateAgentParams(
+            name="Membership", core_model="m", system_prompt="p",
+        ))
+        key_id = result.document.verification_method[0].id
+        key_agreement_doc = result.document.model_copy(
+            update={"key_agreement": [key_id]},
+            deep=True,
+        )
+
+        # Membership predicate must accept the key when keyAgreement is the requested relationship.
+        assert_key_purpose(key_id, key_agreement_doc, "keyAgreement")
+
+        # Signing-purpose policy must still reject keyAgreement for signing flows.
+        with pytest.raises(IdentityCompositionError) as exc:
+            assert_signing_purpose("keyAgreement", key_agreement_doc, key_id)
+        assert exc.value.reason == "key_purpose_violation"
+        assert exc.value.required_purpose == "keyAgreement"
 
 
 class TestAgentIdentityHttpSignature:

--- a/sdk-python/tests/test_interop_vectors.py
+++ b/sdk-python/tests/test_interop_vectors.py
@@ -47,6 +47,7 @@ class TestInteropHttpVector:
                 },
                 "verificationMethod": [vm_data],
                 "authentication": [vm_data["id"]],
+                "assertionMethod": [vm_data["id"]],
             }
         )
         AgentIdentity._resolver.register_document(doc)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -70,6 +70,7 @@ await AgentIdentity.revokeDid(document.id);
 | Sign messages (Ed25519) | `identity.signMessage(payload, key)` | ✅ |
 | Sign HTTP requests (Bot Auth) | `identity.signHttpRequest(params)` | ✅ |
 | Verify message signatures | `AgentIdentity.verifySignature(did, payload, sig)` | ✅ |
+| Enforce key purpose binding | `assertKeyPurpose(keyId, didDoc, purpose)` | ✅ |
 | Verify HTTP signatures | `AgentIdentity.verifyHttpRequestSignature(params)` | ✅ |
 | Resolve DID → document | `AgentIdentity.resolve(did)` | ✅ |
 | Revoke DID | `AgentIdentity.revokeDid(did)` | ✅ |
@@ -78,6 +79,8 @@ await AgentIdentity.revokeDid(document.id);
 | Document history/audit | `AgentIdentity.getDocumentHistory(did)` | ✅ |
 | EVM registry adapter | `EvmAgentRegistry` + `EthersAgentRegistryContractClient` | ✅ |
 | Universal resolver (HTTP/RPC/IPFS) | `UniversalResolverClient` | ✅ |
+
+By default, `verifySignature` and HTTP signature verification require the signing key to be listed under `assertionMethod` in the DID document. Passing a key that exists only under another relationship, including `keyAgreement`, raises `IdentityCompositionError` with reason `key_purpose_violation`.
 
 ## EVM Registry Integration
 

--- a/sdk/src/core/AgentIdentity.ts
+++ b/sdk/src/core/AgentIdentity.ts
@@ -11,6 +11,7 @@ import {
   SignHttpRequestParams,
   UpdateAgentDocumentParams,
   VerifyHttpRequestSignatureParams,
+  VerificationRelationship,
   VerificationMethod
 } from './types';
 import { generateAgentMetadataHash, generateCanonicalDocumentHash } from '../crypto/hash';
@@ -25,6 +26,7 @@ import { JsonRpcDIDDocumentSource } from '../resolver/JsonRpcDIDDocumentSource';
 import { AgentRegistry } from '../registry/types';
 import { InMemoryAgentRegistry } from '../registry/InMemoryAgentRegistry';
 import { normalizeTimestampToIso } from './time';
+import { assertKeyPurpose, assertSigningPurpose, getRelationshipKeyIds } from './identity-composition';
 
 export interface AgentIdentityConfig {
   signer: ethers.Signer; // The Creator's Wallet (Controller)
@@ -143,7 +145,8 @@ export class AgentIdentity {
         memberOf: params.memberOf
       },
       verificationMethod: [verificationMethod],
-      authentication: [verificationMethodId]
+      authentication: [verificationMethodId],
+      assertionMethod: [verificationMethodId]
     };
 
     AgentIdentity.resolver.registerDocument(document);
@@ -306,7 +309,13 @@ export class AgentIdentity {
       });
 
       const signatureHex = Buffer.from(signatureBase64, 'base64').toString('hex');
-      const isValid = await AgentIdentity.verifySignature(signatureAgent, signatureBase, signatureHex, keyId);
+      const isValid = await AgentIdentity.verifySignature(
+        signatureAgent,
+        signatureBase,
+        signatureHex,
+        keyId,
+        'assertionMethod'
+      );
       if (isValid) {
         return true;
       }
@@ -319,7 +328,13 @@ export class AgentIdentity {
    * Verifies that a signature was produced by a specific Agent-DID.
    * Uses the configured resolver and registry to validate against active verification methods.
    */
-  public static async verifySignature(did: string, payload: string, signature: string, keyId?: string): Promise<boolean> {
+  public static async verifySignature(
+    did: string,
+    payload: string,
+    signature: string,
+    keyId?: string,
+    requiredPurpose: VerificationRelationship = 'assertionMethod'
+  ): Promise<boolean> {
     const isRevoked = await AgentIdentity.registry.isRevoked(did);
 
     if (isRevoked) {
@@ -327,12 +342,17 @@ export class AgentIdentity {
     }
 
     const didDoc = await AgentIdentity.resolve(did);
+    assertSigningPurpose(requiredPurpose, didDoc, keyId || '');
+    if (keyId) {
+      assertKeyPurpose(keyId, didDoc, requiredPurpose);
+    }
+
     const messageBytes = new TextEncoder().encode(payload);
     const signatureBytes = hexToBytes(signature);
 
-    const activeKeyIds = new Set(didDoc.authentication || []);
+    const activeKeyIds = new Set(getRelationshipKeyIds(didDoc, requiredPurpose));
     const candidateMethods = didDoc.verificationMethod.filter((method) => {
-      if (!method.publicKeyMultibase) {
+      if (!method.publicKeyMultibase || method.deactivated) {
         return false;
       }
 
@@ -372,7 +392,8 @@ export class AgentIdentity {
     did: string,
     payload: string,
     signature: string,
-    keyId: string
+    keyId: string,
+    requiredPurpose: VerificationRelationship = 'assertionMethod'
   ): Promise<boolean> {
     const isRevoked = await AgentIdentity.registry.isRevoked(did);
     if (isRevoked) {
@@ -380,6 +401,9 @@ export class AgentIdentity {
     }
 
     const didDoc = await AgentIdentity.resolve(did);
+    assertSigningPurpose(requiredPurpose, didDoc, keyId);
+    assertKeyPurpose(keyId, didDoc, requiredPurpose);
+
     const messageBytes = new TextEncoder().encode(payload);
     const signatureBytes = hexToBytes(signature);
 
@@ -484,7 +508,8 @@ export class AgentIdentity {
       ...existing,
       updated: deactivatedTimestamp,
       verificationMethod: [...deactivatedMethods, newVerificationMethod],
-      authentication: [verificationMethodId]
+      authentication: [verificationMethodId],
+      assertionMethod: Array.from(new Set([...(existing.assertionMethod || []), verificationMethodId]))
     };
 
     AgentIdentity.resolver.registerDocument(updatedDocument);

--- a/sdk/src/core/identity-composition.ts
+++ b/sdk/src/core/identity-composition.ts
@@ -1,0 +1,105 @@
+import {
+  AgentDIDDocument,
+  IdentityCompositionErrorReason,
+  SigningVerificationPurpose,
+  VerificationRelationship
+} from './types';
+
+export interface IdentityCompositionErrorDetails {
+  did?: string;
+  keyId: string;
+  requiredPurpose: VerificationRelationship;
+  foundIn: VerificationRelationship[];
+}
+
+export class IdentityCompositionError extends Error {
+  public readonly reason: IdentityCompositionErrorReason;
+  public readonly did?: string;
+  public readonly keyId: string;
+  public readonly requiredPurpose: VerificationRelationship;
+  public readonly foundIn: VerificationRelationship[];
+
+  constructor(reason: IdentityCompositionErrorReason, details: IdentityCompositionErrorDetails) {
+    super(
+      `Verification method ${details.keyId || '<unspecified>'} is not authorized for ${details.requiredPurpose}`
+    );
+    this.name = 'IdentityCompositionError';
+    this.reason = reason;
+    this.did = details.did;
+    this.keyId = details.keyId;
+    this.requiredPurpose = details.requiredPurpose;
+    this.foundIn = [...details.foundIn];
+  }
+}
+
+export const DID_VERIFICATION_RELATIONSHIPS: readonly VerificationRelationship[] = [
+  'authentication',
+  'assertionMethod',
+  'capabilityDelegation',
+  'capabilityInvocation',
+  'keyAgreement'
+];
+
+export const SIGNING_VERIFICATION_PURPOSES: readonly SigningVerificationPurpose[] = [
+  'authentication',
+  'assertionMethod',
+  'capabilityDelegation',
+  'capabilityInvocation'
+];
+
+export function getRelationshipKeyIds(
+  didDoc: AgentDIDDocument,
+  relationship: VerificationRelationship
+): string[] {
+  switch (relationship) {
+    case 'authentication':
+      return didDoc.authentication || [];
+    case 'assertionMethod':
+      return didDoc.assertionMethod || [];
+    case 'capabilityDelegation':
+      return didDoc.capabilityDelegation || [];
+    case 'capabilityInvocation':
+      return didDoc.capabilityInvocation || [];
+    case 'keyAgreement':
+      return didDoc.keyAgreement || [];
+  }
+}
+
+export function getKeyRelationships(keyId: string, didDoc: AgentDIDDocument): VerificationRelationship[] {
+  return DID_VERIFICATION_RELATIONSHIPS.filter((relationship) =>
+    getRelationshipKeyIds(didDoc, relationship).includes(keyId)
+  );
+}
+
+export function assertKeyPurpose(
+  keyId: string,
+  didDoc: AgentDIDDocument,
+  requiredPurpose: VerificationRelationship
+): void {
+  const foundIn = getKeyRelationships(keyId, didDoc);
+  const keyIdsForPurpose = getRelationshipKeyIds(didDoc, requiredPurpose);
+
+  if (requiredPurpose === 'keyAgreement' || !keyIdsForPurpose.includes(keyId)) {
+    throw new IdentityCompositionError('key_purpose_violation', {
+      did: didDoc.id,
+      keyId,
+      requiredPurpose,
+      foundIn
+    });
+  }
+}
+
+export function assertSigningPurpose(
+  requiredPurpose: VerificationRelationship,
+  didDoc: AgentDIDDocument,
+  keyId = ''
+): asserts requiredPurpose is SigningVerificationPurpose {
+  if (requiredPurpose === 'keyAgreement') {
+    throw new IdentityCompositionError('key_purpose_violation', {
+      did: didDoc.id,
+      keyId,
+      requiredPurpose,
+      foundIn: keyId ? getKeyRelationships(keyId, didDoc) : []
+    });
+  }
+}

--- a/sdk/src/core/identity-composition.ts
+++ b/sdk/src/core/identity-composition.ts
@@ -79,7 +79,8 @@ export function assertKeyPurpose(
   const foundIn = getKeyRelationships(keyId, didDoc);
   const keyIdsForPurpose = getRelationshipKeyIds(didDoc, requiredPurpose);
 
-  if (requiredPurpose === 'keyAgreement' || !keyIdsForPurpose.includes(keyId)) {
+  // Membership-only predicate per RFC-001 §6.2.1; signing-purpose policy lives in assertSigningPurpose.
+  if (!keyIdsForPurpose.includes(keyId)) {
     throw new IdentityCompositionError('key_purpose_violation', {
       did: didDoc.id,
       keyId,

--- a/sdk/src/core/types.ts
+++ b/sdk/src/core/types.ts
@@ -37,7 +37,11 @@ export type VerificationRelationship =
 
 export type SigningVerificationPurpose = Exclude<VerificationRelationship, 'keyAgreement'>;
 
-export type IdentityCompositionErrorReason = 'key_purpose_violation';
+export type IdentityCompositionErrorReason =
+  | 'key_purpose_violation'
+  | 'rotation_window_closed'
+  | 'emergency_revoked'
+  | 'tampered';
 
 export interface AgentDIDDocument {
   "@context": string[];

--- a/sdk/src/core/types.ts
+++ b/sdk/src/core/types.ts
@@ -28,6 +28,17 @@ export interface VerificationMethod {
   deactivated?: string; // ISO 8601 timestamp when the key was rotated out
 }
 
+export type VerificationRelationship =
+  | 'authentication'
+  | 'assertionMethod'
+  | 'capabilityDelegation'
+  | 'capabilityInvocation'
+  | 'keyAgreement';
+
+export type SigningVerificationPurpose = Exclude<VerificationRelationship, 'keyAgreement'>;
+
+export type IdentityCompositionErrorReason = 'key_purpose_violation';
+
 export interface AgentDIDDocument {
   "@context": string[];
   id: string; // The Agent's unique DID
@@ -38,6 +49,10 @@ export interface AgentDIDDocument {
   complianceCertifications?: VerifiableCredentialLink[];
   verificationMethod: VerificationMethod[];
   authentication: string[]; // Array of verificationMethod IDs
+  assertionMethod?: string[]; // Keys allowed to sign assertions/messages
+  capabilityDelegation?: string[]; // Keys allowed to issue delegations
+  capabilityInvocation?: string[]; // Keys allowed to invoke delegated capabilities
+  keyAgreement?: string[]; // Keys allowed only for agreement/encryption, not signing
 }
 
 /**

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -14,6 +14,9 @@ export {
   VerifiableCredentialLink,
   VerificationMethod,
   AgentDIDDocument,
+  VerificationRelationship,
+  SigningVerificationPurpose,
+  IdentityCompositionErrorReason,
   CreateAgentParams,
   CreateAgentResult,
   SignHttpRequestParams,
@@ -21,6 +24,17 @@ export {
   RotateVerificationMethodResult,
   VerifyHttpRequestSignatureParams
 } from './core/types';
+
+export {
+  IdentityCompositionError,
+  IdentityCompositionErrorDetails,
+  DID_VERIFICATION_RELATIONSHIPS,
+  SIGNING_VERIFICATION_PURPOSES,
+  assertKeyPurpose,
+  assertSigningPurpose,
+  getKeyRelationships,
+  getRelationshipKeyIds
+} from './core/identity-composition';
 
 // Export Core Identity Class
 export {

--- a/sdk/tests/AgentIdentity.test.ts
+++ b/sdk/tests/AgentIdentity.test.ts
@@ -1,8 +1,10 @@
 import { ethers } from 'ethers';
 import { AgentIdentity } from '../src/core/AgentIdentity';
 import { CreateAgentParams } from '../src/core/types';
+import { assertKeyPurpose, IdentityCompositionError } from '../src/core/identity-composition';
 import { LocalKeySigner } from '../src/core/signer';
 import { InMemoryAgentRegistry } from '../src/registry/InMemoryAgentRegistry';
+import { InMemoryDIDResolver } from '../src/resolver/InMemoryDIDResolver';
 
 describe('AgentIdentity Core Module', () => {
   // Create a random wallet to act as the "Creator" (Controller)
@@ -65,8 +67,9 @@ describe('AgentIdentity Core Module', () => {
     expect(vm.type).toEqual("Ed25519VerificationKey2020");
     expect(vm.blockchainAccountId?.startsWith("eip155:1:0x")).toBe(true);
 
-    // 5. Verify Authentication Binding
+    // 5. Verify verification relationship bindings
     expect(document.authentication).toContain(vm.id);
+    expect(document.assertionMethod).toContain(vm.id);
     
     // 6. Verify Private Key
     expect(result.agentPrivateKey).toBeDefined();
@@ -388,6 +391,108 @@ describe('AgentIdentity Core Module', () => {
     expect(isTamperedValid).toBe(false);
   });
 
+  it('should expose structured key purpose errors for direct helper calls', async () => {
+    const { document } = await agentIdentity.create({
+      name: 'PurposeHelperBot',
+      coreModel: 'test-model',
+      systemPrompt: 'test-prompt'
+    });
+
+    const keyId = document.verificationMethod[0].id;
+    const misboundDocument = {
+      ...document,
+      authentication: [],
+      assertionMethod: [],
+      keyAgreement: [keyId]
+    };
+
+    expect(() => assertKeyPurpose(keyId, misboundDocument, 'assertionMethod')).toThrow(IdentityCompositionError);
+
+    try {
+      assertKeyPurpose(keyId, misboundDocument, 'assertionMethod');
+      throw new Error('assertKeyPurpose should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(IdentityCompositionError);
+      expect(error).toMatchObject({
+        reason: 'key_purpose_violation',
+        keyId,
+        requiredPurpose: 'assertionMethod',
+        foundIn: ['keyAgreement']
+      });
+    }
+  });
+
+  it('should reject signatures from keys outside the required assertionMethod purpose', async () => {
+    const { document, agentPrivateKey } = await agentIdentity.create({
+      name: 'PurposeVerifierBot',
+      coreModel: 'test-model',
+      systemPrompt: 'test-prompt'
+    });
+
+    const keyId = document.verificationMethod[0].id;
+    const payload = 'approve:purpose:1';
+    const signature = await agentIdentity.signMessage(payload, agentPrivateKey);
+    const misboundDocument = {
+      ...document,
+      authentication: [],
+      assertionMethod: [],
+      keyAgreement: [keyId]
+    };
+
+    const resolver = new InMemoryDIDResolver();
+    resolver.registerDocument(misboundDocument);
+    AgentIdentity.setResolver(resolver);
+    AgentIdentity.setRegistry(new InMemoryAgentRegistry());
+
+    await expect(
+      AgentIdentity.verifySignature(document.id, payload, signature, keyId)
+    ).rejects.toMatchObject({
+      reason: 'key_purpose_violation',
+      keyId,
+      requiredPurpose: 'assertionMethod',
+      foundIn: ['keyAgreement']
+    });
+  });
+
+  it('should reject keyAgreement as a signing verification purpose', async () => {
+    const { document, agentPrivateKey } = await agentIdentity.create({
+      name: 'KeyAgreementBot',
+      coreModel: 'test-model',
+      systemPrompt: 'test-prompt'
+    });
+
+    const keyId = document.verificationMethod[0].id;
+    const payload = 'approve:key-agreement:1';
+    const signature = await agentIdentity.signMessage(payload, agentPrivateKey);
+
+    await expect(
+      AgentIdentity.verifySignature(document.id, payload, signature, keyId, 'keyAgreement')
+    ).rejects.toMatchObject({
+      reason: 'key_purpose_violation',
+      requiredPurpose: 'keyAgreement'
+    });
+  });
+
+  it('should reject unknown verification methods with key_purpose_violation', async () => {
+    const { document, agentPrivateKey } = await agentIdentity.create({
+      name: 'UnknownPurposeBot',
+      coreModel: 'test-model',
+      systemPrompt: 'test-prompt'
+    });
+
+    const payload = 'approve:unknown-key:1';
+    const signature = await agentIdentity.signMessage(payload, agentPrivateKey);
+    const unknownKeyId = `${document.id}#key-999`;
+
+    await expect(
+      AgentIdentity.verifySignature(document.id, payload, signature, unknownKeyId)
+    ).rejects.toMatchObject({
+      reason: 'key_purpose_violation',
+      keyId: unknownKeyId,
+      foundIn: []
+    });
+  });
+
   it('should throw when resolving an unknown DID', async () => {
     await expect(AgentIdentity.resolve('did:agent:polygon:0xunknown')).rejects.toThrow('DID not found');
   });
@@ -489,6 +594,10 @@ describe('AgentIdentity Core Module', () => {
     expect(oldValidAfterRotation).toBe(false);
     expect(newValidAfterRotation).toBe(true);
     expect(rotation.document.authentication).toEqual([rotation.verificationMethodId]);
+    expect(rotation.document.assertionMethod).toEqual([
+      `${document.id}#key-1`,
+      rotation.verificationMethodId
+    ]);
   });
 
   it('should mark old keys as deactivated after rotation', async () => {
@@ -548,10 +657,12 @@ describe('AgentIdentity Core Module', () => {
     const payload = 'test-payload';
     const fakeSignature = '00'.repeat(64);
 
-    const valid = await AgentIdentity.verifyHistoricalSignature(
+    await expect(AgentIdentity.verifyHistoricalSignature(
       document.id, payload, fakeSignature, `${document.id}#key-999`
-    );
-    expect(valid).toBe(false);
+    )).rejects.toMatchObject({
+      reason: 'key_purpose_violation',
+      foundIn: []
+    });
   });
 
   it('should keep auditable history for create, update, rotate, revoke lifecycle', async () => {

--- a/sdk/tests/AgentIdentity.test.ts
+++ b/sdk/tests/AgentIdentity.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { AgentIdentity } from '../src/core/AgentIdentity';
 import { CreateAgentParams } from '../src/core/types';
-import { assertKeyPurpose, IdentityCompositionError } from '../src/core/identity-composition';
+import { assertKeyPurpose, assertSigningPurpose, IdentityCompositionError } from '../src/core/identity-composition';
 import { LocalKeySigner } from '../src/core/signer';
 import { InMemoryAgentRegistry } from '../src/registry/InMemoryAgentRegistry';
 import { InMemoryDIDResolver } from '../src/resolver/InMemoryDIDResolver';
@@ -491,6 +491,23 @@ describe('AgentIdentity Core Module', () => {
       keyId: unknownKeyId,
       foundIn: []
     });
+  });
+
+  it('assertKeyPurpose accepts a key listed under keyAgreement when keyAgreement is the requested relationship', async () => {
+    const { document } = await agentIdentity.create({
+      name: 'MembershipBot',
+      coreModel: 'test-model',
+      systemPrompt: 'test-prompt'
+    });
+
+    const keyId = document.verificationMethod[0].id;
+    const keyAgreementDoc = {
+      ...document,
+      keyAgreement: [keyId]
+    };
+
+    expect(() => assertKeyPurpose(keyId, keyAgreementDoc, 'keyAgreement')).not.toThrow();
+    expect(() => assertSigningPurpose('keyAgreement', keyAgreementDoc, keyId)).toThrow(IdentityCompositionError);
   });
 
   it('should throw when resolving an unknown DID', async () => {

--- a/sdk/tests/InteropVectors.test.ts
+++ b/sdk/tests/InteropVectors.test.ts
@@ -42,7 +42,8 @@ describe('Interoperability Vectors', () => {
       systemPromptHash: 'hash://sha256/prompt'
     },
     verificationMethod: [fixture.verificationMethod],
-    authentication: [fixture.verificationMethod.id]
+    authentication: [fixture.verificationMethod.id],
+    assertionMethod: [fixture.verificationMethod.id]
   };
 
   beforeEach(async () => {


### PR DESCRIPTION
Closes #34.

## Summary
- Adds DID verification-relationship binding helpers in the TypeScript and Python SDKs (`assertKeyPurpose` / `assert_key_purpose`) with structured `IdentityCompositionError(reason="key_purpose_violation")`.
- Defaults payload and HTTP signature verification to `assertionMethod`, rejects `keyAgreement` for signing, and reports where a misbound key was found.
- Updates DID document models, create/rotation behavior, interop/conformance tests, and the Microsoft Agent Framework handoff path to request `required_purpose="assertionMethod"`.
- Documents the security/compatibility impact across RFC-001, SDK READMEs, courses, SECURITY, PHILOSOPHY, and deprecation policy.

## Review notes
- Requesting @haroldmalikfrimpong-ops for the Microsoft Agent Framework handoff path, per the #26 / microsoft/agent-framework#4842 review agreement.
- Requesting @aeoess for an A2A §6.3 sanity check on verification-relationship binding (`assertionMethod`, `key_purpose_violation`, `keyAgreement` rejection).

## Validation
- `npm --prefix sdk run build`
- `npm --prefix sdk test`
- `.\.conda\python.exe -m pytest sdk-python/tests -q`
- `.\.conda\python.exe -m pytest integrations/microsoft-agent-framework/tests -q`
- `.\.conda\python.exe -m ruff check integrations/microsoft-agent-framework/src integrations/microsoft-agent-framework/tests integrations/microsoft-agent-framework/examples`
- `git diff --check`
