### PR TITLE
[Docs] Re-add RFC link to contributor navigation block

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ OAuth delegates this to a centralized provider. MCP leaves it out of scope by de
 > - Contribution workflow: [CONTRIBUTING.md](CONTRIBUTING.md)
 > - Security reporting: [SECURITY.md](SECURITY.md)
 > - Docs navigation: [docs/INDEX.md](docs/INDEX.md)
+> - RFC under Public Review: [docs/RFC-001-Agent-DID-Specification.md](docs/RFC-001-Agent-DID-Specification.md)
 > - Compatibility expectations: [docs/DEPRECATION-POLICY.md](docs/DEPRECATION-POLICY.md)
 
 Built on W3C DID and Verifiable Credentials, Agent-DID provides:


### PR DESCRIPTION
## Summary

Adds the missing RFC link back to the contributor navigation block in README.md. PR #25 had replaced the original `> New here?` line with a 5-link contributor navigation block but dropped the RFC link. This fix restores it.

## Changes

- Added `RFC under Public Review: docs/RFC-001-Agent-DID-Specification.md` line to the `> For contributors (Public Review):` block in README.md
- Positioned between `Docs navigation` and `Compatibility expectations` lines as specified in the issue

## Completes

- Closes #29

## How to verify

1. Review the updated README.md contributor navigation block
2. Confirm the RFC link is present and points to the correct file
3. No other sections were modified
