### PR TITLE
feat: add runnable Node quickstart example under sdk/examples

### DIFF
--- a/sdk/examples/quickstart_http_sign_verify.js
+++ b/sdk/examples/quickstart_http_sign_verify.js
@@ -1,0 +1,34 @@
+const { AgentIdentity, InMemoryAgentRegistry } = require('@agentdid/sdk');
+const { ethers } = require('ethers');
+
+const main = async () => {
+  AgentIdentity.setRegistry(new InMemoryAgentRegistry());
+
+  const wallet = ethers.Wallet.createRandom();
+  const identity = new AgentIdentity({ signer: wallet, network: 'polygon' });
+
+  const created = await identity.create({
+    name: 'quickstart-bot',
+    coreModel: 'gpt-4.1-mini',
+    systemPrompt: 'Sign outbound API requests.'
+  });
+
+  const headers = await identity.signHttpRequest({
+    method: 'POST',
+    url: 'https://api.example.com/tasks',
+    body: '{"taskId":7}',
+    agentPrivateKey: created.agentPrivateKey,
+    agentDid: created.document.id
+  });
+
+  const ok = await AgentIdentity.verifyHttpRequestSignature({
+    method: 'POST',
+    url: 'https://api.example.com/tasks',
+    body: '{"taskId":7}',
+    headers
+  });
+
+  console.log({ did: created.document.id, ok, headerNames: Object.keys(headers).sort() });
+};
+
+void main();


### PR DESCRIPTION
Fixes #15

Adds a runnable Node.js quickstart example under sdk/examples.

This example demonstrates:
- Agent identity creation
- HTTP request signing
- Signature verification
- End-to-end local execution using in-memory registry

Verified locally with:
node sdk/examples/quickstart_http_sign_verify.js