### PR TITLE
feat: add runnable Node quickstart example (fixes #15)

### DIFF
--- a/sdk/examples/quickstart.js
+++ b/sdk/examples/quickstart.js
@@ -1,0 +1,40 @@
+// Run: node sdk/examples/quickstart.js
+
+const { AgentIdentity, InMemoryAgentRegistry } = require('../dist');
+const { ethers } = require('ethers');
+
+const main = async () => {
+  AgentIdentity.setRegistry(new InMemoryAgentRegistry());
+
+  const wallet = ethers.Wallet.createRandom();
+  const identity = new AgentIdentity({ signer: wallet, network: 'polygon' });
+
+  const created = await identity.create({
+    name: 'quickstart-bot',
+    coreModel: 'gpt-4.1-mini',
+    systemPrompt: 'Sign outbound API requests.'
+  });
+
+  const headers = await identity.signHttpRequest({
+    method: 'POST',
+    url: 'https://api.example.com/tasks',
+    body: '{"taskId":7}',
+    agentPrivateKey: created.agentPrivateKey,
+    agentDid: created.document.id
+  });
+
+  const ok = await AgentIdentity.verifyHttpRequestSignature({
+    method: 'POST',
+    url: 'https://api.example.com/tasks',
+    body: '{"taskId":7}',
+    headers
+  });
+
+  console.log({
+    did: created.document.id,
+    ok,
+    headerNames: Object.keys(headers).sort()
+  });
+};
+
+void main();


### PR DESCRIPTION
Fixes #15

Adds a runnable Node quickstart example under sdk/examples.

- Uses in-memory registry
- Signs HTTP request
- Verifies signature
- Uses local SDK build (../dist)
- Runs with: node sdk/examples/quickstart.js