### PR TITLE
release: prepare 1.0.0-rc.1 train

### DIFF
--- a/.github/workflows/publish-release-train.yml
+++ b/.github/workflows/publish-release-train.yml
@@ -1,0 +1,329 @@
+name: Publish 1.0 Release Train
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      python_repository:
+        description: "Target Python package repository"
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - pypi
+      npm_tag:
+        description: "npm dist-tag for npm packages"
+        required: true
+        default: next
+        type: string
+
+concurrency:
+  group: publish-release-train-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-typescript-sdk:
+    name: Build npm package — @agentdid/sdk
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20.18.0
+          cache: npm
+          cache-dependency-path: sdk/package-lock.json
+
+      - name: Verify tag matches @agentdid/sdk version
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: sdk
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag version $TAG_VERSION does not match sdk/package.json version $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Install SDK dependencies
+        run: npm --prefix sdk ci
+
+      - name: Check TypeScript public API snapshot
+        run: npm --prefix sdk run api:check
+
+      - name: Check TypeScript public API signature snapshot
+        run: npm --prefix sdk run api:signature:check
+
+      - name: Run TypeScript SDK tests with coverage gate
+        run: npm --prefix sdk test -- --coverage --runInBand
+
+      - name: Build TypeScript SDK
+        run: npm --prefix sdk run build
+
+      - name: Pack TypeScript SDK tarball
+        working-directory: sdk
+        run: npm pack
+
+      - name: Upload TypeScript SDK tarball
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: typescript-sdk-tarball
+          path: sdk/*.tgz
+          if-no-files-found: error
+
+  build-langchain-js:
+    name: Build npm package — @agentdid/langchain
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20.18.0
+
+      - name: Verify tag matches @agentdid/langchain version
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: integrations/langchain
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag version $TAG_VERSION does not match integrations/langchain/package.json version $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Install and build shared TypeScript SDK
+        run: |
+          npm --prefix sdk ci
+          npm --prefix sdk run build
+
+      - name: Install LangChain JS dependencies
+        run: npm --prefix integrations/langchain ci
+
+      - name: Run LangChain JS tests
+        run: npm --prefix integrations/langchain test
+
+      - name: Pack LangChain JS tarball
+        working-directory: integrations/langchain
+        run: npm pack
+
+      - name: Upload LangChain JS tarball
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: langchain-js-tarball
+          path: integrations/langchain/*.tgz
+          if-no-files-found: error
+
+  publish-npm:
+    name: Publish npm packages
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    needs:
+      - build-typescript-sdk
+      - build-langchain-js
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact_name: typescript-sdk-tarball
+            package_name: '@agentdid/sdk'
+          - artifact_name: langchain-js-tarball
+            package_name: '@agentdid/langchain'
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download package tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20.18.0
+          registry-url: https://registry.npmjs.org
+
+      - name: Resolve npm dist-tag
+        id: npm_meta
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "dist_tag=${{ inputs.npm_tag }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_REF_NAME#v}" == *-* ]]; then
+            echo "dist_tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish npm package with provenance
+        run: npm publish dist/*.tgz --access public --provenance --tag "${{ steps.npm_meta.outputs.dist_tag }}"
+
+  build-python-packages:
+    name: Build Python package — ${{ matrix.package_name }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package_dir: sdk-python
+            package_name: agent-did-sdk
+            artifact_name: agent-did-sdk-dist
+          - package_dir: integrations/langchain-python
+            package_name: agent-did-langchain
+            artifact_name: agent-did-langchain-dist
+          - package_dir: integrations/crewai
+            package_name: agent-did-crewai
+            artifact_name: agent-did-crewai-dist
+          - package_dir: integrations/semantic-kernel
+            package_name: agent-did-semantic-kernel
+            artifact_name: agent-did-semantic-kernel-dist
+          - package_dir: integrations/microsoft-agent-framework
+            package_name: agent-did-microsoft-agent-framework
+            artifact_name: agent-did-microsoft-agent-framework-dist
+          - package_dir: integrations/a2a
+            package_name: agent-did-a2a
+            artifact_name: agent-did-a2a-dist
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Verify tag matches Python package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: ${{ matrix.package_dir }}
+        shell: bash
+        run: |
+          PACKAGE_VERSION=$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))
+          print(data['project']['version'])
+          PY
+          )
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          NORMALIZED_TAG=$(python - "$TAG_VERSION" <<'PY'
+          import re
+          import sys
+
+          raw = sys.argv[1]
+          match = re.fullmatch(r'(\d+\.\d+\.\d+)(?:-(a|alpha|b|beta|rc)\.?(\d+))?', raw)
+          if match is None:
+              raise SystemExit(f'Unsupported release tag format: {raw}')
+
+          base, label, number = match.groups()
+          if label is None:
+              print(base)
+          else:
+              normalized_label = {'alpha': 'a', 'beta': 'b'}.get(label, label)
+              print(f'{base}{normalized_label}{number}')
+          PY
+          )
+
+          if [ "$PACKAGE_VERSION" != "$NORMALIZED_TAG" ]; then
+            echo "Tag version $TAG_VERSION normalizes to $NORMALIZED_TAG but ${{ matrix.package_dir }}/pyproject.toml declares $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Build Python distribution
+        working-directory: ${{ matrix.package_dir }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Upload Python distribution artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.package_dir }}/dist/*
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish Python packages to TestPyPI
+    if: github.event_name == 'workflow_dispatch' && inputs.python_repository == 'testpypi'
+    needs: build-python-packages
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact_name: agent-did-sdk-dist
+          - artifact_name: agent-did-langchain-dist
+          - artifact_name: agent-did-crewai-dist
+          - artifact_name: agent-did-semantic-kernel-dist
+          - artifact_name: agent-did-microsoft-agent-framework-dist
+          - artifact_name: agent-did-a2a-dist
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist
+
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish Python packages to PyPI
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.python_repository == 'pypi' && github.ref == 'refs/heads/main')
+    needs: build-python-packages
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact_name: agent-did-sdk-dist
+          - artifact_name: agent-did-langchain-dist
+          - artifact_name: agent-did-crewai-dist
+          - artifact_name: agent-did-semantic-kernel-dist
+          - artifact_name: agent-did-microsoft-agent-framework-dist
+          - artifact_name: agent-did-a2a-dist
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 - `README.md`, `sdk/README.md`, `sdk-python/README.md`, and `SECURITY.md` now consistently frame EVM/on-chain material as an optional deferred profile rather than a core `1.0.0` assumption.
 - `docs/RELEASE-1.0-CRITERIA.md`, `README.md`, and this changelog now treat `1.0.0-rc.1` as the default first prerelease and reserve the 30-day green-window gate for the final stable `v1.0.0` tag.
+- RFC-001 is now marked Stable in-repo for the `1.0.0-rc.1` release train, with `docs/INDEX.md`, `docs/RFC-001-CHANGELOG.md`, and `docs/DEPRECATION-POLICY.md` aligned to the frozen release contract.
+- Core package manifests are now pinned to the `1.0.0-rc.1` release train (`1.0.0-rc.1` on npm packages, `1.0.0rc1` on Python packages) and a unified `publish-release-train.yml` workflow now orchestrates prerelease publication across npm and PyPI.
 
 ### Planned (path to 1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -108,29 +108,30 @@ Documentation governance for live project status and canonical sources of truth 
 
 The project is past the specification-only phase: it includes a functional implementation and a validation pipeline.
 
-- **RFC-001** is in **Public Review v1** as `0.3-pivot-pattern-on-webvh`: [docs/RFC-001-Agent-DID-Specification.md](docs/RFC-001-Agent-DID-Specification.md)
+- **RFC-001** is now **Stable** in-repo as the frozen `1.0` contract for the `1.0.0-rc.1` release train: [docs/RFC-001-Agent-DID-Specification.md](docs/RFC-001-Agent-DID-Specification.md)
 - **Compliance checklist**: [docs/RFC-001-Compliance-Checklist.md](docs/RFC-001-Compliance-Checklist.md)
 - **Current result**: MUST `11/11 PASS` and SHOULD `5/5 PASS`
-- **Published SDKs**: `@agentdid/sdk` `0.2.0` on npm and `agent-did-sdk` `0.1.0` on PyPI
+- **Repository release train**: core npm packages are pinned to `1.0.0-rc.1`; core Python packages are pinned to `1.0.0rc1`
+- **Latest public stable SDKs before the RC cut**: `@agentdid/sdk` `0.2.0` on npm and `agent-did-sdk` `0.1.0` on PyPI
 - **`0.x -> 1.0` migration**: [sdk/MIGRATION-0.x-to-1.0.md](sdk/MIGRATION-0.x-to-1.0.md), [sdk-python/MIGRATION-0.x-to-1.0.md](sdk-python/MIGRATION-0.x-to-1.0.md)
 - **Release-train evidence**: [docs/RELEASE-1.0-CRITERIA.md](docs/RELEASE-1.0-CRITERIA.md), [docs/RELEASE-1.0-COMPATIBILITY-MATRIX.md](docs/RELEASE-1.0-COMPATIBILITY-MATRIX.md), [docs/RELEASE-1.0-INTEGRATION-EVIDENCE.md](docs/RELEASE-1.0-INTEGRATION-EVIDENCE.md)
-- **Current release target**: `1.0.0-rc.1` is the intended first prerelease for the stable path; the 30-day green-window gate applies to final `v1.0.0`, not to the RC cut
+- **Current RC work**: publish the `1.0.0-rc.1` prerelease train, validate public-registry clean-install smokes, switch the demo to the RC, and open the focused feedback window; the 30-day green-window gate applies only to final `v1.0.0`
 - **Start here**: [QUICKSTART.md](QUICKSTART.md), [SECURITY.md](SECURITY.md), [docs/INDEX.md](docs/INDEX.md), [docs/DEPRECATION-POLICY.md](docs/DEPRECATION-POLICY.md)
 
 ## Build In Public
 
-Agent-DID is an open, pre-1.0 project being built in public.
+Agent-DID is an open project being finalized in public for the `1.0.0-rc.1` release train.
 
-- The core RFC lifecycle is implemented and covered by conformance checks.
-- The TypeScript SDK is published as `@agentdid/sdk` and the Python SDK is published as `agent-did-sdk`.
+- The core RFC lifecycle is implemented, covered by conformance checks, and frozen in-repo as the current Stable release contract.
+- The next public publication step is the co-versioned `1.0.0-rc.1` prerelease across the shipped SDK and integration packages.
 - The `did:webvh` runtime path, validation drills, and framework integrations are functional, and the release path now explicitly follows `did:webvh` as the canonical deployment story.
-- Community feedback is explicitly welcome before the project reaches full production hardening.
-- Public-review compatibility expectations are documented in [docs/DEPRECATION-POLICY.md](docs/DEPRECATION-POLICY.md).
+- Community feedback is explicitly welcome during the RC window before the final `v1.0.0` tag.
+- RC and post-`1.0` compatibility expectations are documented in [docs/DEPRECATION-POLICY.md](docs/DEPRECATION-POLICY.md).
 - Security reporting instructions are documented in [SECURITY.md](SECURITY.md).
 
 If you want to help shape the next stage, the highest-leverage open areas today are:
 
-- **v1.0 RC execution and stable hardening**: cut `1.0.0-rc.1`, validate public-registry clean install smokes, and continue accumulating the 30-day green evidence required for final `v1.0.0`
+- **v1.0 RC publication and stable hardening**: publish and validate `1.0.0-rc.1`, then continue accumulating the 30-day green evidence required for final `v1.0.0`
 - **F2-03** production resolver hardening beyond the shipped source-adapter baseline
 - **F2-07** formal whitepaper publication
 - **F2-08** Azure AI Agent Service integration

--- a/docs/DEPRECATION-POLICY.md
+++ b/docs/DEPRECATION-POLICY.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Agent-DID is in a pre-1.0 Public Review phase. That is the right time for strong feedback, but it is also the moment when maintainers need to be explicit about how change is handled.
+Agent-DID has now frozen the public contract for the `1.0.0-rc.1` release train. That is late enough that compatibility rules must be explicit even though the final stable tag is still pending release validation.
 
 This policy defines how the project communicates deprecations, breaking changes, and support expectations across:
 
@@ -13,19 +13,32 @@ This policy defines how the project communicates deprecations, breaking changes,
 
 ## Current Compatibility Phase
 
-Agent-DID is currently **pre-1.0** and under **Public Review**.
+Agent-DID is currently in the **`1.0.0-rc.1` release-candidate phase**.
 
 That means:
 
-- the RFC can still evolve based on community feedback
-- the SDKs are usable today, but some public APIs and wire-level expectations may still change
-- maintainers will prefer compatibility when possible, but correctness, interoperability, and security take priority over short-term stability
+- RFC-001 text is treated as Stable for this release train
+- the SDK public APIs, DID document shape, and runtime verification contract are expected to remain frozen
+- remaining repo changes before `v1.0.0` should be limited to bugfixes, documentation corrections, packaging, CI hardening, and release operations
+- if a public-contract change is still required, maintainers should cut another prerelease rather than slipping a breaking change into the active RC
 
 ## Versioning Expectations
 
+### RC changes before `v1.0.0`
+
+During the RC phase:
+
+- fixes should preserve backward compatibility for the frozen public contract
+- any intentional diff in the signature-level API snapshot, required DID document format, or default verification semantics is a release-contract change, not a routine bugfix
+- deferred EVM/on-chain profile work may evolve independently, but it does not redefine the core `1.0` compatibility floor unless it changes the RFC, the shipped SDK API, or the web-native verification contract
+
+### Historical pre-1.0 note
+
+Before the `1.0.0-rc.1` freeze, minor releases could include breaking changes during Public Review. That exception no longer applies to the RC branch.
+
 ### Patch releases
 
-Patch releases should not intentionally introduce breaking changes.
+Patch releases after `1.0.0` must not intentionally introduce breaking changes.
 
 Typical patch-release work includes:
 
@@ -37,14 +50,25 @@ Typical patch-release work includes:
 
 ### Minor releases
 
-Before v1.0, **minor releases may include breaking changes** when one of the following is true:
+Minor releases after `1.0.0` add backward-compatible functionality.
 
-- the RFC changes during Public Review
-- an interoperability defect must be corrected
-- a security issue requires a behavior change
-- an API surface is still experimental and needs simplification
+Typical minor-release work includes:
 
-When a minor release contains a breaking change, maintainers will document it explicitly in release notes and, when practical, provide migration guidance.
+- additive APIs or helpers that do not break the existing signature-level public surface
+- new optional integration capabilities
+- new compatibility profiles or adapters that do not alter the core `did:webvh` contract
+- editorial or operational updates that accompany backward-compatible feature growth
+
+When a minor release adds public functionality, maintainers should update release notes and migration guidance when adoption steps are needed.
+
+### Major releases
+
+Major releases are required for incompatible changes, including:
+
+- intentional diffs in the signature-level API snapshots
+- changes to DID document requiredness or semantics
+- breaking changes to verification defaults, signing semantics, or lifecycle behavior
+- incompatible package renames, import-path changes, or bootstrap-surface changes
 
 ## Deprecation Window
 
@@ -71,7 +95,7 @@ In those cases, maintainers will still document:
 - why it changed immediately
 - how to migrate
 
-Public Review example: SDK signature verification now enforces DID verification-relationship binding by default. Agent payload and HTTP signatures require `assertionMethod`, and a key listed only under another relationship such as `keyAgreement` fails with `key_purpose_violation`. Documents that previously placed signing keys only in `authentication` should add the appropriate signing relationship.
+Recent example: SDK signature verification now enforces DID verification-relationship binding by default. Agent payload and HTTP signatures require `assertionMethod`, and a key listed only under another relationship such as `keyAgreement` fails with `key_purpose_violation`. Documents that previously placed signing keys only in `authentication` should add the appropriate signing relationship.
 
 ## What Counts as a Breaking Change
 
@@ -84,8 +108,11 @@ The following should be treated as breaking unless explicitly documented otherwi
 - changing revocation, key rotation, or resolution behavior in a way that can flip a previous pass to a fail
 - changing canonical serialization rules used by signing or verification
 - changing package names, import paths, or integration bootstrap APIs
+- changing the core `did:webvh` release contract to depend on deferred EVM/on-chain profile contracts, ABIs, or deployment metadata
 
 After `1.0.0`, any intentional diff in the signature-level public API snapshot must be treated as a **major-version** change unless the symbol is explicitly out of the public contract.
+
+Changes limited to deferred EVM/on-chain profile contracts, ABIs, deployment metadata, or audit artifacts do **not** by themselves alter the core `1.0` compatibility contract unless they also change the RFC, the shipped SDK surface, or the release-critical web-native verification semantics.
 
 ## Communication Rules
 

--- a/docs/F1-03-LangChain-Integration-Parity-Review-Checklist.md
+++ b/docs/F1-03-LangChain-Integration-Parity-Review-Checklist.md
@@ -55,6 +55,7 @@ Run this checklist when a change affects one or more of the following:
 ## Documentation And Examples
 
 - [ ] `integrations/langchain/README.md` and `integrations/langchain-python/README.md` still describe the same conceptual model.
+- [ ] If release-candidate metadata changes, both READMEs still document the coordinated prerelease install path (`@next` on npm, `1.0.0rc1` on Python) without implying divergent runtime behavior.
 - [ ] If a local quickstart clarifies controller bootstrap or hosted `did:webvh` publication boundaries, both READMEs still describe that deployment split consistently.
 - [ ] Both packages still ship, at minimum, base, observability and production-style examples.
 - [ ] If one package ships an integrated `did:wba` demo, the other package ships an equivalent integrated `did:wba` demo or the divergence is explicit in docs.
@@ -96,6 +97,7 @@ Parity verification is complete when:
 
 | Date | Change |
 |------|--------|
+| 2026-05-08 | Added a governance check for coordinated RC metadata so TS/Python README guidance stays aligned when the release train uses ecosystem-native prerelease versions. |
 | 2026-05-08 | Added a review gate for README changes that clarify local controller bootstrap vs hosted `did:webvh` publication so the TS/Python conceptual model stays aligned. |
 | 2026-05-04 | Added parity review coverage for `assertionMethod` binding in signing-capable `did:wba` demo DID documents. |
 | 2026-03-31 | Repository slug updated to `agent-did` and active LangChain TS/Python package references normalized to `@agentdid/*` in README/examples/metadata. No functional changes to the integration surface; parity artifacts refreshed for governance compliance. |

--- a/docs/F1-03-LangChain-TS-Python-Integration-Parity-Matrix.md
+++ b/docs/F1-03-LangChain-TS-Python-Integration-Parity-Matrix.md
@@ -63,6 +63,7 @@ La parity de integracion se define en cinco dimensiones:
 | Receta tipo produccion | `agentDidLangChain.productionRecipe.example.js` | `agent_did_langchain_production_recipe_example.py` | ✅ | Ambos usan guardas de entorno. |
 | Demo integrado `did:wba` | `agentDidLangChain.didWbaDemo.example.js` | `agent_did_langchain_did_wba_demo.py` | ✅ | Ambos muestran runtime `did:wba`, partner remoto `did:wba`, `createAgent`/`create_agent` local y firma HTTP verificable sin credenciales externas. Los DID documents de demo declaran las claves de firma en `assertionMethod` para cumplir el binding de relaciones de verificacion del SDK. |
 | Smoke cross-package `did:wba` | `npm run smoke:langchain-didwba` ejecuta el demo JavaScript publicado y valida su contrato JSON. | El mismo comando ejecuta el demo Python publicado y valida su contrato JSON en la misma corrida. | ✅ | Este smoke es gate de parity operativa entre ambos demos, no solo una conveniencia local. |
+| Metadata de release candidate | `@agentdid/langchain@1.0.0-rc.1` y peer `@agentdid/sdk@1.0.0-rc.1` | `agent-did-langchain==1.0.0rc1` y `agent-did-sdk==1.0.0rc1` | ✅ | La parity de publicacion usa normalizacion nativa por ecosistema sin cambiar el contrato funcional entre TS y Python. |
 | Integracion LangSmith dedicada | `createLangSmithRunTree(...)` + `createLangSmithEventHandler(...)` | Adapter dedicado disponible | ✅ | Ambos paquetes exponen adaptador dedicado sin cambiar la factory principal. |
 | Profundidad de suite automatizada | tests funcionales, seguridad y observabilidad | tests funcionales, seguridad, observabilidad y modulos internos | ⚠️ | Python sigue mas granular. |
 
@@ -127,6 +128,7 @@ La parity de integraciones LangChain TS vs Python se considera mantenida cuando:
 
 | Fecha | Cambio |
 |-------|--------|
+| 2026-05-08 | Se agrego una fila de parity para la metadata de release candidate: LangChain JS queda en `1.0.0-rc.1` con peer `@agentdid/sdk@1.0.0-rc.1`, mientras LangChain Python queda en `1.0.0rc1` con dependencia `agent-did-sdk==1.0.0rc1`. La divergencia de formato es solo normalizacion por ecosistema. |
 | 2026-05-08 | README de LangChain JS refrescado para dejar explicito que el flujo local usa bootstrap del controller web-native y que la publicacion hospedada de `did:webvh` es un concern separado. La matriz mantiene parity con Python sobre ese modelo conceptual. |
 | 2026-05-04 | Los demos integrados `did:wba` TS/Python ahora declaran `assertionMethod` en los DID documents usados para firma HTTP, manteniendo parity con el enforcement de key purpose binding del SDK. |
 | 2026-03-31 | Rename del repositorio a `agent-did` y normalizacion de metadata publica para LangChain TS/Python: URLs de GitHub, referencias de instalacion y ejemplos activos alineados con `@agentdid/sdk` y `@agentdid/langchain`. Sin cambios en la API publica ni en la parity funcional. |

--- a/docs/F2-04-Semantic-Kernel-Implementation-Checklist.md
+++ b/docs/F2-04-Semantic-Kernel-Implementation-Checklist.md
@@ -13,6 +13,7 @@ Use this checklist when implementation work starts or when a PR changes the pack
 - [x] The package declares itself as `functional` and that status matches the shipped integration surface.
 - [x] `integrations/semantic-kernel/README.md` no longer describes the Python SDK as future work.
 - [x] `docs/F2-04-Semantic-Kernel-Integration-Design.md` still matches the intended runtime surface.
+- [x] RC metadata stays aligned with the coordinated `1.0.0rc1` release train and the package now carries the frozen `agent-did-sdk==1.0.0rc1` dependency floor expected for the core RC.
 
 ---
 
@@ -87,5 +88,6 @@ F2-04 is implementation-ready for release review when the package has a function
 
 | Date | Change |
 |------|--------|
+| 2026-05-08 | RC metadata refreshed for the coordinated `1.0.0rc1` release train and the checklist now records the frozen `agent-did-sdk==1.0.0rc1` dependency expectation. |
 | 2026-03-31 | Repository slug updated to `agent-did` and Semantic Kernel package metadata aligned to the new GitHub URL and `Agent-DID contributors` branding. No runtime, tool, middleware or API surface changes. |
 | 2026-03-22 | Repository license migrated from MIT to Apache-2.0. `pyproject.toml` updated accordingly. No functional changes to the integration surface. |

--- a/docs/F2-04-Semantic-Kernel-Integration-Review-Checklist.md
+++ b/docs/F2-04-Semantic-Kernel-Integration-Review-Checklist.md
@@ -24,6 +24,7 @@ Run this checklist when a change affects one or more of the following:
 - [ ] The package status is still correct for the shipped state (`functional` for the current Python integration surface).
 - [ ] README, design doc and package metadata describe the same current state.
 - [ ] No Semantic Kernel document refers to the Python SDK as future work.
+- [ ] If release metadata changes, the README and package metadata still agree on the coordinated `1.0.0rc1` dependency on `agent-did-sdk`.
 
 ---
 
@@ -81,5 +82,6 @@ Semantic Kernel review is complete when the scaffold state is accurately describ
 
 | Date | Change |
 |------|--------|
+| 2026-05-08 | Added an explicit review gate for RC metadata alignment so README/package metadata stay synchronized during the `1.0.0rc1` freeze. |
 | 2026-03-31 | Repository slug updated to `agent-did` and Semantic Kernel package metadata refreshed to the new GitHub URL and project branding. Review artifacts updated to record that the change is packaging/governance-only, with no functional integration drift. |
 | 2026-03-22 | Repository license migrated from MIT to Apache-2.0. `pyproject.toml` updated accordingly. No functional changes to the integration surface. |

--- a/docs/F2-05-CrewAI-Implementation-Checklist.md
+++ b/docs/F2-05-CrewAI-Implementation-Checklist.md
@@ -14,6 +14,7 @@ Use this checklist when implementation work starts or when a PR changes CrewAI p
 - [x] `integrations/crewai/README.md` no longer describes the Python SDK as future work.
 - [x] `docs/F2-05-CrewAI-Integration-Design.md` still matches the intended CrewAI surface.
 - [x] `docs/F2-05-CrewAI-Maturity-Gap-Assessment.md` remains the reference document for the remaining maturity delta versus LangChain.
+- [x] RC metadata stays aligned with the coordinated `1.0.0rc1` release train and the package continues to declare `agent-did-sdk==1.0.0rc1` as its core dependency floor for the frozen release candidate.
 
 ---
 
@@ -77,4 +78,5 @@ F2-05 is complete for repo scope when the package has a functional factory, expl
 
 | Date | Change |
 |------|--------|
+| 2026-05-08 | RC metadata refreshed for the coordinated `1.0.0rc1` release train and the checklist now records the frozen `agent-did-sdk==1.0.0rc1` dependency expectation. |
 | 2026-03-22 | Repository license migrated from MIT to Apache-2.0. `pyproject.toml` updated accordingly. No functional changes to the integration surface. |

--- a/docs/F2-05-CrewAI-Integration-Review-Checklist.md
+++ b/docs/F2-05-CrewAI-Integration-Review-Checklist.md
@@ -24,6 +24,7 @@ Run this checklist when a change affects one or more of the following:
 - [ ] The package status is still correct for the shipped state (`functional` while the current `Agent`/`Task`/`Crew` helper surface remains accurate).
 - [ ] README, design doc and package metadata describe the same current state.
 - [ ] No CrewAI document refers to the Python SDK as future work.
+- [ ] If release metadata changes, the README and package metadata still agree on the coordinated `1.0.0rc1` dependency on `agent-did-sdk`.
 
 ---
 
@@ -84,4 +85,5 @@ CrewAI review is complete when the current package state is accurately described
 
 | Date | Change |
 |------|--------|
+| 2026-05-08 | Added an explicit review gate for RC metadata alignment so README/package metadata stay synchronized during the `1.0.0rc1` freeze. |
 | 2026-03-22 | Repository license migrated from MIT to Apache-2.0. `pyproject.toml` updated accordingly. No functional changes to the integration surface. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -36,8 +36,8 @@ This index is the fast path through the repository documentation.
 |---|---|---|---|
 | [INDEX.md](INDEX.md) | Users, Contributors, Reviewers | Stable | Entry point for navigating the docs set. |
 | [Documentation-Governance.md](Documentation-Governance.md) | Contributors, Reviewers | Stable | Defines canonical sources of truth and live-document update rules. |
-| [DEPRECATION-POLICY.md](DEPRECATION-POLICY.md) | Users, Contributors, Reviewers | Stable | Explains breaking-change and support expectations during Public Review. |
-| [RFC-001-Agent-DID-Specification.md](RFC-001-Agent-DID-Specification.md) | Users, Contributors, Reviewers | Draft | Canonical Agent-DID specification under Public Review. |
+| [DEPRECATION-POLICY.md](DEPRECATION-POLICY.md) | Users, Contributors, Reviewers | Stable | Explains RC freeze, post-`1.0` SemVer, and compatibility expectations for the published packages. |
+| [RFC-001-Agent-DID-Specification.md](RFC-001-Agent-DID-Specification.md) | Users, Contributors, Reviewers | Stable | Canonical Agent-DID specification, frozen as the `1.0` release contract for the current RC train. |
 | [RFC-001-EVM-Profile.md](RFC-001-EVM-Profile.md) | Contributors, Reviewers | Draft | Optional deployment profile for EVM anchoring, contract policy, and smart-account behavior on top of core RFC-001. |
 | [RFC-001-A2A-Identity-Composition-Contract.md](RFC-001-A2A-Identity-Composition-Contract.md) | Contributors, Reviewers | Draft | Defines the A2A Agent Card and per-request signing composition contract co-drafted with APS. |
 | [RFC-001-Compliance-Checklist.md](RFC-001-Compliance-Checklist.md) | Contributors, Reviewers | Stable | Tracks RFC conformance claims against implemented behavior. |

--- a/docs/RELEASE-1.0-CRITERIA.md
+++ b/docs/RELEASE-1.0-CRITERIA.md
@@ -153,7 +153,7 @@ If future user demand creates a concrete EVM/on-chain need, the project will eva
 
 ### 2.10 Release Engineering
 
-- [ ] **C-REL-1** — All core packages bumped simultaneously under a single monorepo tag for each prerelease stage used (`1.0.0-beta.N`, if any, and `1.0.0-rc.N`). The first RC cut for the stable path is `1.0.0-rc.1`.
+- [ ] **C-REL-1** — All core packages bumped simultaneously under a single monorepo tag for each prerelease stage used (`1.0.0-beta.N`, if any, and `1.0.0-rc.N`). The first RC cut for the stable path is `1.0.0-rc.1`. Package manifests may use ecosystem-native prerelease normalization when required by the registry (`1.0.0-rc.1` on npm, `1.0.0rc1` on PyPI).
 - [ ] **C-REL-2** — Public feedback window of **≥1 week** on the RC, announced on GitHub Discussions.
 - [ ] **C-REL-3** — `v1.0.0` tag only after every criterion above is met.
 - [ ] **C-REL-4** — Release note and README status update coordinated with the tag. Broad public announcement is optional and should follow the visibility gates in `docs/Estrategia-Divulgacion-2-Semanas-Agent-DID.md`.
@@ -221,6 +221,17 @@ Goal: cut the appropriate prerelease (`beta` only if contract-shaping feedback i
 | S2-7 | `DEPRECATION-POLICY.md` updated with strict SemVer post-1.0 | tech-writer | C-DOC-3 |
 | S2-8 | `v1.0.0` tag + consolidated release notes + final publication | dev + pm | C-REL-3 |
 | S2-9 | README `1.0` badge/status update and release note; broader announcement only if visibility gates are met | pm | C-REL-4, C-DOC-6 |
+
+#### RC Tag Plan
+
+The coordinated `1.0.0-rc.1` cut uses a single monorepo release tag with ecosystem-native prerelease normalization:
+
+1. npm packages declare `1.0.0-rc.1`.
+2. Python packages declare `1.0.0rc1`.
+3. The coordinated release tag is `v1.0.0-rc.1`.
+4. `.github/workflows/publish-release-train.yml` is the coordinated publication entrypoint for the core release train.
+5. npm prereleases publish under dist-tag `next`; PyPI packages publish as prerelease versions derived from the normalized Python manifests.
+6. Legacy `sdk-v*` and `sdk-python-v*` tags remain package-specific workflows for SDK-only publication paths and are not the coordinated core RC tag.
 
 ---
 

--- a/docs/RFC-001-Agent-DID-Specification.md
+++ b/docs/RFC-001-Agent-DID-Specification.md
@@ -2,11 +2,13 @@
 
 ## Document Status
 
-- **Status:** Public Review v1 (open for community feedback)
+- **Status:** Stable
 - **Version:** 0.3-pivot-pattern-on-webvh
-- **Date:** 2026-05-06
+- **Date:** 2026-05-08
 - **Scope:** This RFC is the canonical core specification for Agent-DID as an application pattern on top of `did:webvh`, including the data model, composition semantics, runtime authentication profile, and SDK implementation guidelines.
-- **Feedback:** Use the RFC feedback issue template or GitHub Discussions for public review. Report vulnerabilities privately through [SECURITY.md](../SECURITY.md).
+- **Feedback:** Use the RFC feedback issue template or GitHub Discussions for errata, clarifications, and post-`1.0` proposals. Report vulnerabilities privately through [SECURITY.md](../SECURITY.md).
+
+This Stable status means the repository treats RFC-001 as the frozen compatibility contract for the `1.0.0-rc.1` release train. It does **not** imply W3C, DIF, or any other external standards-body approval.
 
 ---
 
@@ -330,6 +332,16 @@ RFC-001 conformance establishes identity/delegation and runtime signature-verifi
 The operational compliance evaluation is maintained in:
 
 - `docs/RFC-001-Compliance-Checklist.md`
+
+### 11.2 Errata and Post-1.0 Corrections
+
+After `1.0.0`, corrections to this RFC must follow an explicit errata path:
+
+1. File the proposed correction through GitHub Discussions or the RFC feedback issue template and link the affected section.
+2. Maintainers classify the proposal as one of: editorial erratum, compatible clarification, or normative change.
+3. Editorial errata and non-behavioral clarifications may be merged into this document and recorded in `docs/RFC-001-CHANGELOG.md` without requiring a major version bump.
+4. Any accepted change that alters conformance obligations, DID document requiredness, verification semantics, or the signature-level public API compatibility contract must ship under a new release plan and, after `1.0.0`, a SemVer major release.
+5. Every accepted erratum must update any affected conformance fixtures, implementation notes, or migration guidance in the same change set.
 
 ---
 

--- a/docs/RFC-001-CHANGELOG.md
+++ b/docs/RFC-001-CHANGELOG.md
@@ -2,7 +2,23 @@
 
 This document tracks normative and materially relevant editorial changes to RFC-001 independently from the ecosystem release train tracked in [../CHANGELOG.md](../CHANGELOG.md).
 
-> **Current canonical text:** [RFC-001-Agent-DID-Specification.md](RFC-001-Agent-DID-Specification.md) is now at `0.3-pivot-pattern-on-webvh`.
+> **Current canonical text:** [RFC-001-Agent-DID-Specification.md](RFC-001-Agent-DID-Specification.md) is Stable and frozen for the `1.0.0-rc.1` release train.
+
+---
+
+## [stable-promotion-1.0.0-rc.1] - 2026-05-08
+
+### Decision Trigger
+
+- Sprint 1 hardening, API freeze, and release-train evidence were completed for the core `did:webvh` path.
+- The release train moved into the `1.0.0-rc.1` freeze, so the RFC text needed to stop presenting itself as an open Public Review contract.
+
+### Result
+
+- RFC-001 document header was promoted from Public Review to Stable.
+- `docs/INDEX.md` now classifies RFC-001 as Stable.
+- RFC governance now includes an explicit errata procedure for post-`1.0` corrections.
+- Stable in this repository means the release contract is frozen; it does not claim W3C, DIF, or external standards-body approval.
 
 ---
 

--- a/docs/SDK-Release-Checklist.md
+++ b/docs/SDK-Release-Checklist.md
@@ -6,6 +6,8 @@ Provide a single repository-level release checklist for the TypeScript SDK in `s
 
 Documentation status and canonical-source rules are defined in `docs/Documentation-Governance.md`.
 
+For the coordinated core `1.0.0` prerelease/stable train, the canonical publication entrypoint is `.github/workflows/publish-release-train.yml` driven by a monorepo tag such as `v1.0.0-rc.1`. The package-specific workflows `.github/workflows/publish-sdk.yml` and `.github/workflows/publish-python-sdk.yml` remain valid for SDK-only release paths.
+
 This checklist is intended for:
 
 1. Release preparation.

--- a/integrations/a2a/pyproject.toml
+++ b/integrations/a2a/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-did-a2a"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "Google A2A protocol integration for Agent-DID — DID-based identity, AgentCard enrichment, and HTTP Signature authentication for agent-to-agent communication."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -13,7 +13,7 @@ authors = [
   { name = "Edison Munoz", email = "edison.munoz@agent-did.org" }
 ]
 dependencies = [
-  "agent-did-sdk>=0.1.0",
+  "agent-did-sdk==1.0.0rc1",
   "pydantic>=2.0",
 ]
 

--- a/integrations/crewai/README.md
+++ b/integrations/crewai/README.md
@@ -37,7 +37,7 @@ Integrar Agent-DID como capa de identidad verificable para agentes y crews de Cr
 
 ## Compatibilidad objetivo
 
-- `agent-did-sdk >=0.1.0`
+- `agent-did-sdk ==1.0.0rc1`
 - Python 3.10+
 - CrewAI host runtime opcional via `python -m pip install -e ".[runtime]"`; el paquete expone herramientas compatibles sin forzar dependencia dura para tests locales del repo
 

--- a/integrations/crewai/pyproject.toml
+++ b/integrations/crewai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-did-crewai"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "CrewAI Python integration for Agent-DID identities, compatible tools, callbacks and secure opt-in operations."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -13,7 +13,7 @@ authors = [
   { name = "Edison Munoz", email = "edison.munoz@agent-did.org" }
 ]
 dependencies = [
-  "agent-did-sdk>=0.1.0",
+  "agent-did-sdk==1.0.0rc1",
   "pydantic>=2.0",
 ]
 

--- a/integrations/langchain-python/README.md
+++ b/integrations/langchain-python/README.md
@@ -20,12 +20,20 @@ Ahora tambien expone una capa ligera de observabilidad vendor-neutral basada en 
 
 ## Compatibilidad objetivo
 
-- `agent-did-sdk >=0.1.0`
+- `agent-did-sdk ==1.0.0rc1`
 - `langchain >=1.2.13,<1.3`
 - `langchain-core >=1.2.20,<1.3`
 - Python 3.10+
 
 ## Instalacion
+
+Para el paquete publicado del release candidate, la ruta objetivo es:
+
+```bash
+python -m pip install agent-did-sdk==1.0.0rc1 agent-did-langchain==1.0.0rc1
+```
+
+Mientras la publicacion del RC corre, la validacion canonica en el repo sigue siendo:
 
 ```bash
 python -m pip install -e ../../sdk-python

--- a/integrations/langchain-python/pyproject.toml
+++ b/integrations/langchain-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-did-langchain"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "LangChain Python integration for Agent-DID identities, context injection and secure tool exposure."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["agent-did", "langchain", "python", "did", "identity", "tool-calling"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
@@ -24,7 +24,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "agent-did-sdk>=0.1.0",
+  "agent-did-sdk==1.0.0rc1",
   "langchain>=1.2.13,<1.3",
   "langchain-core>=1.2.20,<1.3",
   "pydantic>=2.0",

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -10,7 +10,7 @@ La matriz de parity entre ambas integraciones vive en `../../docs/F1-03-LangChai
 
 - `langchain` `^1.2.35`
 - `@langchain/core` `^1.1.34`
-- `@agentdid/sdk` `^0.2.0`
+- `@agentdid/sdk` `1.0.0-rc.1`
 - Node.js 20+
 
 ## Estado
@@ -23,7 +23,7 @@ La matriz de parity entre ambas integraciones vive en `../../docs/F1-03-LangChai
 ## Instalacion
 
 ```bash
-npm install @agentdid/sdk langchain @langchain/core zod
+npm install @agentdid/sdk@next langchain @langchain/core zod
 ```
 
 Para habilitar el adaptador opcional de LangSmith:
@@ -35,7 +35,7 @@ npm install langsmith
 Si publicas este paquete por separado:
 
 ```bash
-npm install @agentdid/langchain
+npm install @agentdid/langchain@next
 ```
 
 ## Uso rapido

--- a/integrations/langchain/package-lock.json
+++ b/integrations/langchain/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentdid/langchain",
-  "version": "0.1.0",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentdid/langchain",
-      "version": "0.1.0",
+      "version": "1.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.25.76"
@@ -26,7 +26,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@agentdid/sdk": "^0.1.0",
+        "@agentdid/sdk": "1.0.0-rc.1",
         "@langchain/core": "^1.1.34",
         "langchain": "^1.2.35",
         "langsmith": "^0.5.10"
@@ -39,12 +39,14 @@
     },
     "../../sdk": {
       "name": "@agentdid/sdk",
-      "version": "0.1.0",
+      "version": "1.0.0-rc.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.4.0",
+        "agent-did": "file:..",
+        "bs58": "^6.0.0",
         "ethers": "^6.11.1",
         "multiformats": "^13.1.0"
       },

--- a/integrations/langchain/package.json
+++ b/integrations/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdid/langchain",
-  "version": "0.1.0",
+  "version": "1.0.0-rc.1",
   "description": "LangChain integration for Agent-DID identities with middleware and tools for LangChain JS 1.x agents.",
   "main": "src/index.js",
   "files": [
@@ -24,8 +24,11 @@
   ],
   "author": "Edison Munoz <edison.munoz@agent-did.org>",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
-    "@agentdid/sdk": "^0.1.0",
+    "@agentdid/sdk": "1.0.0-rc.1",
     "@langchain/core": "^1.1.34",
     "langchain": "^1.2.35",
     "langsmith": "^0.5.10"

--- a/integrations/microsoft-agent-framework/pyproject.toml
+++ b/integrations/microsoft-agent-framework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-did-microsoft-agent-framework"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "Microsoft Agent Framework Python integration for Agent-DID identities, native tools and sanitized observability."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -13,7 +13,7 @@ authors = [
   { name = "Edison Munoz", email = "edison.munoz@agent-did.org" }
 ]
 dependencies = [
-  "agent-did-sdk>=0.1.0",
+  "agent-did-sdk==1.0.0rc1",
   "agent-framework>=1.0.0rc5,<1.1",
   "pydantic>=2.0",
 ]

--- a/integrations/semantic-kernel/pyproject.toml
+++ b/integrations/semantic-kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-did-semantic-kernel"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "Semantic Kernel Python integration for Agent-DID identities, tools, context injection and secure opt-in operations."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["agent-did", "semantic-kernel", "python", "did", "identity", "tool-calling"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
@@ -24,7 +24,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "agent-did-sdk>=0.1.0",
+  "agent-did-sdk==1.0.0rc1",
   "pydantic>=2.0",
 ]
 

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -6,7 +6,7 @@ Functional parity with the TypeScript SDK (`@agentdid/sdk`), with a dedicated Py
 
 Formal parity tracking is documented in `../docs/F2-01-TS-Python-Parity-Matrix.md`.
 
-> **Public Review note:** Agent-DID is pre-1.0 and the RFC is still under community review. See [../docs/DEPRECATION-POLICY.md](../docs/DEPRECATION-POLICY.md) for compatibility and breaking-change expectations during this phase.
+> **Release-candidate note:** The repository is frozen for the `1.0.0-rc.1` release train and RFC-001 is now treated as Stable text. Final `v1.0.0` publication still depends on the remaining gates in [../docs/RELEASE-1.0-CRITERIA.md](../docs/RELEASE-1.0-CRITERIA.md).
 >
 > **Moving from `0.x`?** See [MIGRATION-0.x-to-1.0.md](MIGRATION-0.x-to-1.0.md).
 
@@ -19,7 +19,7 @@ Pythonic surface conventions apply:
 ## Installation
 
 ```bash
-pip install agent-did-sdk
+pip install agent-did-sdk==1.0.0rc1
 ```
 
 For development:

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-did-sdk"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "Python SDK for the Agent-DID Specification (RFC-001) — create, sign, resolve, verify and revoke Agent-DIDs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["did", "agent", "identity", "decentralized", "web3", "ai"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",

--- a/sdk-python/src/agent_did_sdk.egg-info/PKG-INFO
+++ b/sdk-python/src/agent_did_sdk.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: agent-did-sdk
-Version: 0.1.0
+Version: 1.0.0rc1
 Summary: Python SDK for the Agent-DID Specification (RFC-001) — create, sign, resolve, verify and revoke Agent-DIDs
 Author: Agent-DID contributors
 License-Expression: Apache-2.0
@@ -8,7 +8,7 @@ Project-URL: Homepage, https://github.com/edisonduran/agent-did#readme
 Project-URL: Repository, https://github.com/edisonduran/agent-did.git
 Project-URL: Bug-Tracker, https://github.com/edisonduran/agent-did/issues
 Keywords: did,agent,identity,decentralized,web3,ai
-Classifier: Development Status :: 3 - Alpha
+Classifier: Development Status :: 4 - Beta
 Classifier: Intended Audience :: Developers
 Classifier: Programming Language :: Python :: 3
 Classifier: Programming Language :: Python :: 3.10
@@ -39,7 +39,7 @@ Functional parity with the TypeScript SDK (`@agentdid/sdk`), with a dedicated Py
 
 Formal parity tracking is documented in `../docs/F2-01-TS-Python-Parity-Matrix.md`.
 
-> **Public Review note:** Agent-DID is pre-1.0 and the RFC is still under community review. See [../docs/DEPRECATION-POLICY.md](../docs/DEPRECATION-POLICY.md) for compatibility and breaking-change expectations during this phase.
+> **Release-candidate note:** The repository is frozen for the `1.0.0-rc.1` release train and RFC-001 is now treated as Stable text. Final `v1.0.0` publication still depends on the remaining gates in [../docs/RELEASE-1.0-CRITERIA.md](../docs/RELEASE-1.0-CRITERIA.md).
 >
 > **Moving from `0.x`?** See [MIGRATION-0.x-to-1.0.md](MIGRATION-0.x-to-1.0.md).
 
@@ -52,7 +52,7 @@ Pythonic surface conventions apply:
 ## Installation
 
 ```bash
-pip install agent-did-sdk
+pip install agent-did-sdk==1.0.0rc1
 ```
 
 For development:

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -8,7 +8,7 @@ Verifiable decentralized identity for autonomous AI agents. Create, sign, resolv
 
 > **SDK en TypeScript para identidad descentralizada verificable de agentes de IA autónomos.**
 >
-> **Public Review note:** Agent-DID is pre-1.0 and the RFC is still under community review. See [../docs/DEPRECATION-POLICY.md](../docs/DEPRECATION-POLICY.md) for compatibility and breaking-change expectations during this phase.
+> **Release-candidate note:** The repository is frozen for the `1.0.0-rc.1` release train and RFC-001 is now treated as Stable text. Final `v1.0.0` publication still depends on the remaining gates in [../docs/RELEASE-1.0-CRITERIA.md](../docs/RELEASE-1.0-CRITERIA.md).
 >
 > **Moving from `0.x`?** See [MIGRATION-0.x-to-1.0.md](MIGRATION-0.x-to-1.0.md).
 
@@ -30,7 +30,7 @@ Agent-DID solves this with:
 ## Installation
 
 ```bash
-npm install @agentdid/sdk ethers
+npm install @agentdid/sdk@next ethers
 ```
 
 Requires **Node.js 18+**.

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentdid/sdk",
-  "version": "0.2.0",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentdid/sdk",
-      "version": "0.2.0",
+      "version": "1.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.4.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentdid/sdk",
-  "version": "0.2.0",
+  "version": "1.0.0-rc.1",
   "description": "TypeScript SDK for creating, signing, and verifying Agent-DIDs based on RFC-001. Decentralized identity for autonomous AI agents with Ed25519 signatures, HTTP Bot Auth, and EVM registry support.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- prepare the coordinated `1.0.0-rc.1` release train across core packages
- add a unified `publish-release-train.yml` workflow driven by `vX.Y.Z[-rc.N]`
- promote RFC-001 to Stable in-repo and align SemVer/deprecation guidance with the RC freeze

## Validation
- `npm --prefix sdk run build`
- `npm run interop:check`
- `npm run test:langchain`
- `npm pack --dry-run` in `sdk/`
- `npm pack --dry-run` in `integrations/langchain/`
- `python -m build` for `sdk-python/` and the core Python integrations

## Remaining external blockers before closing Sprint 2 as published RC
- confirm/npm Trusted Publishing and PyPI Trusted Publishing for all core packages
- create or configure the missing PyPI integration package publishers
- publish the RC train and capture public-registry smoke evidence
- switch the demo and open the focused feedback window
