### PR TITLE
fix: publish npm tarballs from local paths

### DIFF
--- a/.github/workflows/publish-release-train.yml
+++ b/.github/workflows/publish-release-train.yml
@@ -174,7 +174,7 @@ jobs:
           fi
 
       - name: Publish npm package with provenance
-        run: npm publish dist/*.tgz --access public --provenance --tag "${{ steps.npm_meta.outputs.dist_tag }}"
+        run: npm publish ./dist/*.tgz --access public --provenance --tag "${{ steps.npm_meta.outputs.dist_tag }}"
 
   build-python-packages:
     name: Build Python package — ${{ matrix.package_name }}

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -89,4 +89,4 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Publish TypeScript SDK to npm with provenance
-        run: npm publish dist/*.tgz --access public --provenance
+        run: npm publish ./dist/*.tgz --access public --provenance


### PR DESCRIPTION
## Summary
- fix npm publish steps to use explicit local tarball paths in the coordinated release-train workflow
- align the legacy TypeScript SDK publish workflow with the same local-path fix
- document that the failed `v1.0.0-rc.1` run also hit an external PyPI trusted-publisher blocker (`invalid-publisher`), which is not resolved by this PR

## Validation
- reproduced the bug locally: `npm publish --dry-run sdk/agentdid-sdk-1.0.0-rc.1.tgz` fails because npm treats the path as GitHub shorthand
- confirmed the fix locally: `npm publish --dry-run ./sdk/agentdid-sdk-1.0.0-rc.1.tgz` succeeds
- workflow YAML passes editor validation